### PR TITLE
fix crash from undefined channel var

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -157,7 +157,7 @@ Commander.prototype.process = function (line) {
     self.view.writeLine(`${cmd} is not a command, type /help for commands`)
   } else {
     line = line.trim()
-    if (line !== '' && channel !== "!status") {
+    if (line !== '' && self.channel !== "!status") {
       self.cabal.publish({
         type: 'chat/text',
         content: {


### PR DESCRIPTION
```
ReferenceError: channel is not defined
    at Commander.process (/home/substack/projects/cabal/cabal/commands.js:160:24)
    at EventEmitter.NeatScreen.neat.input.on (/home/substack/projects/cabal/cabal/neat-screen.js:43:56)
    at EventEmitter.emit (events.js:189:13)
    at onenter (/home/substack/projects/cabal/cabal/node_modules/neat-input/index.js:176:11)
    at handle (/home/substack/projects/cabal/cabal/node_modules/neat-input/index.js:122:11)
    at ReadStream.onkeypress (/home/substack/projects/cabal/cabal/node_modules/neat-input/index.js:181:9)
    at ReadStream.emit (events.js:189:13)
    at emitKey (/home/substack/projects/cabal/cabal/node_modules/keypress/index.js:406:12)
    at ReadStream.onData (/home/substack/projects/cabal/cabal/node_modules/keypress/index.js:48:14)
    at ReadStream.emit (events.js:189:13)
```