### PR TITLE
improve newline handling for messages containing \n

### DIFF
--- a/util.js
+++ b/util.js
@@ -38,11 +38,7 @@ function wrapAnsi (text, width, padding=11) {
       if (lineLen >= width - 1 || chr === '\n') {
         res.push(line.join(''))
         line = [" ".repeat(padding)]
-        lineLen = 0
-      }
-      if (chr === '\n') {
-        line = [" ".repeat(padding)]
-        lineLen = line.length
+        lineLen = padding
       }
     }
 


### PR DESCRIPTION
fixes wrapping long messages containing newlines (i.e. messages likely to come from desktop-like clients)

see #133 for more info