### PR TITLE
improve autocomplete of nicknames

### DIFF
--- a/neat-screen.js
+++ b/neat-screen.js
@@ -66,10 +66,12 @@ function NeatScreen (props) {
         }
         match = [line.slice(lindex, rindex).trim()]
       }
+      if (!match) return
 
-      let cyclingNicks = (this.state.prevCompletion !== undefined)
-      if (cyclingNicks && match[0].startsWith(this.state.prevCompletion[0])) {
+      let cyclingNicks = false
+      if (this.state.prevCompletion !== undefined && match[0].startsWith(this.state.prevCompletion[0])) {
         match = this.state.prevCompletion
+        cyclingNicks = true
       } else {
         delete this.state.prevCompletion
         delete this.state.prevNickIndex

--- a/neat-screen.js
+++ b/neat-screen.js
@@ -46,9 +46,9 @@ function NeatScreen (props) {
       const cursor = this.neat.input.cursor
       let lindex = -1
       let rindex = -1
-      const wanderingCursor = cursor !== line.length
+      const cursorWandering = cursor !== line.length
       // we're trying to autocomplete something in the middle of the line; i.e the cursor has wandered away from the end
-      if (wanderingCursor) {
+      if (cursorWandering) {
         // find left-most boundary of potential nickname fragment to autocomplete
         for (let i = cursor - 1; i > 0; i--) {
           if (line.charAt(i) === ' ') {
@@ -73,14 +73,15 @@ function NeatScreen (props) {
           const filteredUser = filteredUsers[0]
           let currentInput = this.neat.input.rawLine()
           let completedInput = currentInput.slice(0, currentInput.length - word.length) + filteredUser
-          if (wanderingCursor) {
+          if (cursorWandering) {
             completedInput = currentInput.slice(0, lindex + 1) + filteredUser + currentInput.slice(rindex)
           }
           if (completedInput === filteredUser) { completedInput += ': ' } // we only autcompleted a single nick, add a colon and space
           this.neat.input.set(completedInput)
-          console.error(lindex, rindex, currentInput.slice(lindex, rindex))
-          // move cursor to right after the completed nickname
-          this.neat.input.cursor = cursor + (filteredUser.length - currentInput.slice(lindex, rindex).trim().length) // if cursor is not wandering => .slice(-1,-1) will give us an empty string => ""
+          // when neat-input.set() is used the cursor is automatically moved to the end of the line, if the cursor is wandering we instead want the cursor to be just after the autocompleted name
+          if (cursorWandering) {
+            this.neat.input.cursor = cursor + (filteredUser.length - currentInput.slice(lindex, rindex).trim().length) 
+          }
           return
         }
       }

--- a/neat-screen.js
+++ b/neat-screen.js
@@ -138,7 +138,12 @@ function NeatScreen (props) {
     if (!key || !key.name) return
     if (key.name === 'home') this.neat.input.cursor = 0
     else if (key.name === 'end') this.neat.input.cursor = this.neat.input.rawLine().length
-    else return
+    else if (key.name !== 'tab' && this.state.prevCompletion) {
+      delete this.state.prevCompletion
+      delete this.state.prevNickIndex
+    } else {
+      return
+    }
     this.bus.emit('render')
   })
 

--- a/neat-screen.js
+++ b/neat-screen.js
@@ -79,7 +79,7 @@ function NeatScreen (props) {
       }
 
       // proceed to figure out the closest match
-      const filteredUsers = Array.from(new Set(users.filter(user => user.toLowerCase().startsWith(match.toLowerCase())))) // filter out duplicate nicks
+      const filteredUsers = Array.from(new Set(users.filter(user => user.search(/\s+/) === -1 && user.toLowerCase().startsWith(match.toLowerCase())))) // filter out duplicate nicks and people with spaces in their nicks, fuck that 
       if (filteredUsers.length > 0) {
         const userIndex = cyclingNicks ? (this.state.prevNickIndex + 1) % filteredUsers.length : 0
         const filteredUser = filteredUsers[userIndex]

--- a/neat-screen.js
+++ b/neat-screen.js
@@ -86,23 +86,23 @@ function NeatScreen (props) {
         const currentInput = this.neat.input.rawLine()
         let completedInput = currentInput.slice(0, currentInput.length - match.length) + filteredUser
         // i.e. repeated tabbing of similar-starting nicks
-        if (cyclingNicks) { 
+        if (cyclingNicks) {
           let prevNick = filteredUsers[this.state.prevNickIndex]
           // we autocompleted a single nick w/ colon+space added, adjust for colon+space
-          if (currentInput.length === prevNick.length + 2) { prevNick += ": " } 
+          if (currentInput.length === prevNick.length + 2) { prevNick += ': ' }
           completedInput = currentInput.slice(0, currentInput.length - prevNick.length) + filteredUser
         }
         // i.e. cursor has been moved from end of line
         if (cursorWandering) {
-          completedInput = (lindex > 0) ? currentInput.slice(0, lindex + 1) : ""
+          completedInput = (lindex > 0) ? currentInput.slice(0, lindex + 1) : ''
           completedInput += filteredUser + currentInput.slice(rindex)
         }
         // ux: we only autcompleted a single nick, add a colon and space
-        if (completedInput === filteredUser) { 
-          completedInput += ': ' 
-        } 
+        if (completedInput === filteredUser) {
+          completedInput += ': '
+        }
         this.neat.input.set(completedInput) // update the input line with our newly tab-completed nick
-        // when neat-input.set() is used the cursor is automatically moved to the end of the line, 
+        // when neat-input.set() is used the cursor is automatically moved to the end of the line,
         // if the cursor is wandering we instead want the cursor to be just after the autocompleted name
         if (cursorWandering) {
           this.neat.input.cursor = cursor + (filteredUser.length - currentInput.slice(lindex, rindex).trim().length)


### PR DESCRIPTION
nicknames can now be autocompleted anywhere in the line and multiple
times. the first nickname that matches the word the cursor is closest to
is chosen

e.g. if i try to autcomplete the following, `_` marking cursor position,

> hey ne_

i can match both `neist` and `nettle`. since `neist` lexicographically comes before `nettle`, we currently autocomplete to `neist`

if anyone has neat ideas on how to easily allow for tabbing from one match of the possible nickname to the next let me know :3
