### PR TITLE
sanitize usernames across the cli

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -34,7 +34,7 @@ function Commander (view, client) {
       call: (arg) => {
         if (arg === '') return
         this.cabal.publishNick(arg)
-        this.view.writeLine("* you're now known as " + arg)
+        this.view.writeLine("* you're now known as " + util.sanitizeString(arg))
       }
     },
     emote: {
@@ -57,7 +57,7 @@ function Commander (view, client) {
         var userkeys = Object.keys(users).map((key) => users[key]).sort(util.cmpUser)
         logToView('* history of peers in this cabal')
         userkeys.map((u) => {
-          var username = u.name || 'conspirator'
+          var username = util.sanitizeString(u.name) || 'conspirator'
           var spaces = ' '.repeat(15)
           var paddedName = (username + spaces).slice(0, spaces.length)
           logToView(`  ${paddedName} ${u.key}`)

--- a/neat-screen.js
+++ b/neat-screen.js
@@ -384,12 +384,14 @@ NeatScreen.prototype.formatMessage = function (msg) {
     const users = this.client.getUsers()
     const authorSource = users[msg.key] || msg
 
-    const author = authorSource.name || authorSource.key.slice(0, 8)
+    const author = util.sanitizeString(authorSource.name || authorSource.key.slice(0, 8))
     // add author field for later use in calculating the left-padding of multi-line messages
     msg.author = author
     var localNick = 'uninitialized'
     if (this.state) { localNick = this.state.cabal.getLocalName() }
-    /* sanitize input to prevent interface from breaking */
+
+    /* sanitize user inputs to prevent interface from breaking */
+    localNick = util.sanitizeString(localNick)
     var msgtxt = msg.value.content.text
     if (msg.value.type !== 'status') {
       msgtxt = util.sanitizeString(msgtxt)

--- a/views.js
+++ b/views.js
@@ -83,7 +83,7 @@ function linkSize (state) {
 }
 
 function renderPrompt (state) {
-  var name = state.cabal ? state.cabal.getLocalName() : 'unknown'
+  var name = util.sanitizeString(state.cabal ? state.cabal.getLocalName() : 'unknown')
   return [
     `[${chalk.cyan(name)}:${state.cabal.getCurrentChannel()}] ${state.neat.input.line()}`
   ]
@@ -156,7 +156,7 @@ function renderNicks (state, width, height) {
   users = users
     .map(function (user) {
       var name = ''
-      if (user && user.name) name += user.name.slice(0, width)
+      if (user && user.name) name += util.sanitizeString(user.name).slice(0, width)
       else name += user.key.slice(0, Math.min(8, width))
       if (user.online) { onlines[name] = name in onlines ? onlines[name] + 1 : 1 }
       return name


### PR DESCRIPTION
we now clean the nicknames that are displayed in the cli such that everything doesn't explode anymore, which fixes #144 

it looks like this 
![image](https://user-images.githubusercontent.com/3862362/73448735-d2751a80-4361-11ea-86da-380fcfe45939.png)

currently not sure how mentions fare, and i would personally prefer if people did not use emojis in nicknames in the public cabal (as it looks a bit ugly and takes up a lot of space) but at least things the cli doesn't break now