### PR TITLE
show online handles as bold

### DIFF
--- a/views.js
+++ b/views.js
@@ -165,10 +165,10 @@ function renderNicks (state, width, height) {
   var nickCount = {}
   users.forEach(function (u) { nickCount[u] = u in nickCount ? nickCount[u] + 1 : 1 })
   return users.filter((u, i, arr) => arr.indexOf(u) === i).map((u) => {
-    if (nickCount[u] === 1) return u in onlines ? u : chalk.gray(u)
+    if (nickCount[u] === 1) return u in onlines ? chalk.bold(u) : chalk.gray(u)
     var dupecount = ` (${nickCount[u]})`
     var name = u.slice(0, 15 - dupecount.length)
-    return (u in onlines ? name : chalk.gray(name)) + chalk.green(dupecount)
+    return (u in onlines ? chalk.bold(name) : chalk.gray(name)) + chalk.green(dupecount)
   }).slice(0, height)
 }
 


### PR DESCRIPTION
I don't know how it looks for everyone else but on my terminal it's pretty hard to tell which handles I'm connected to. This patch sets bold mode for online peers to make it more clear.

Before:

![before](https://user-images.githubusercontent.com/12631/79018988-ecc13680-7b10-11ea-9fc3-ed8f2d19bfc7.png)

After:

![after](https://user-images.githubusercontent.com/12631/79018994-f185ea80-7b10-11ea-8ac4-4e5bf6186450.png)
