### PR TITLE
error out on trying to alias an unknown key

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -178,6 +178,10 @@ if (args.alias && !args.key) {
 
 // user wants to alias a cabal:// key with a name
 if (args.alias && args.key) {
+  if (!cabalKeys.find(function(k) { return k === args.key })) {
+    console.log(console.error("Error: Couldn't resolve cabal key:", chalk.yellow(args.key)))
+    process.exit(1)
+  }
   config.aliases[args.alias] = args.key
   saveConfig(configFilePath, config)
   console.log(`${chalk.magentaBright('cabal:')} saved ${chalk.greenBright(args.key)} as ${chalk.blueBright(args.alias)}`)


### PR DESCRIPTION
this PR limits chances for stale aliases and erroneous configurations; personally, i ended up wondering why i got confronted with dns errors until i checked config.yaml and found that i misconfigured an alias; this could help...