### PR TITLE
debounce the keyboard input so pasting text is fast

### DIFF
--- a/neat-screen.js
+++ b/neat-screen.js
@@ -15,6 +15,8 @@ function NeatScreen (props) {
   this.client = props.client
   this.config = props.frontendConfig
   this.commander = Commander(this, this.client)
+  this.lastInputTime = 0
+  this.inputTimer = null
   var self = this
 
   this.neat = neatLog(this.renderApp.bind(this), {
@@ -25,7 +27,21 @@ function NeatScreen (props) {
     }
   }
   )
-  this.neat.input.on('update', () => this.neat.render())
+  this.neat.input.on('update', () => {
+    // debounce keyboard input events so pasting from clipboard is fast
+    var now = Date.now()
+    var ms = 20
+    if (this.inputTimer) {
+    } else if (now > this.lastInputTime + ms) {
+      this.lastInputTime = now
+      this.neat.render()
+    } else {
+      this.inputTimer = setTimeout(() => {
+        this.inputTimer = null
+        this.neat.render()
+      }, ms)
+    }
+  })
   this.neat.input.on('enter', (line) => this.commander.process(line))
 
   // welcome to autocomplete town


### PR DESCRIPTION
Previously, if you pasted a link or a snippet from the clipboard, the characters would type out one at a time and it would take sometimes ~0.5s to 1s to see what you pasted in the input box. This was even worse on my older laptop. With this debouncing logic, when I paste from the clipboard I see what I pasted instantly and typing text feels the same.