### PR TITLE
fix edgecase on startup with --new flag

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -205,30 +205,30 @@ if (args.join) {
   cabalKeys = [getKey(args.join)]
 }
 
-if (!cabalKeys.length) {
+// try to initiate the frontend using either qr codes via webcam, using cabal keys passed via cli, 
+// or starting an entirely new cabal per --new
+if (args.qr) {
+  console.log('Cabal is looking for a QR code...')
+  console.log('Press ctrl-c to stop.')
+  captureQrCode({ retry: true }).then((key) => {
+    if (key) {
+      console.log('\u0007') // system bell
+      start([key], config.frontend)
+    } else {
+      console.log('No QR code detected.')
+      process.exit(0)
+    }
+  }).catch((e) => {
+    console.error('Webcam capture failed. Have you installed the appropriate drivers? See the documentation for more information.')
+    console.error('Mac OSX: brew install imagesnap')
+    console.error('Linux: sudo apt-get install fswebcam')
+  })
+} else if (cabalKeys.length || args.new) {
+    start(cabalKeys, config.frontend)
+} else {
+  // no keys, no qr, and not trying to start a new cabal => print help info
   process.stderr.write(usage)
   process.exit(1)
-} else {
-  if (args.qr) {
-    console.log('Cabal is looking for a QR code...')
-    console.log('Press ctrl-c to stop.')
-    captureQrCode({ retry: true }).then((key) => {
-      if (key) {
-        console.log('\u0007') // system bell
-        start([key], config.frontend)
-      } else {
-        console.log('No QR code detected.')
-        process.exit(0)
-      }
-    })
-      .catch((e) => {
-        console.error('Webcam capture failed. Have you installed the appropriate drivers? See the documentation for more information.')
-        console.error('Mac OSX: brew install imagesnap')
-        console.error('Linux: sudo apt-get install fswebcam')
-      })
-  } else {
-    start(cabalKeys, config.frontend)
-  }
 }
 
 function start (keys, frontendConfig) {


### PR DESCRIPTION
@dominictarr found an edgecase where, when you're first starting to use cabal and the _very first_ action you take is try to create a new cabal, we unhelpfully (and accidentally) printed the help message and then quit the process. lol

this has now been fixed!

what should also be fixed: if you start cabal for the first time and the first thing you try to do is join a cabal via qr code, it too would have triggered the above behaviour

fix #162 