### PR TITLE
replace --join with --save, add --cabals, fix multicabal joining

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,26 @@ e.g.
 cabal cabal://0201400f1aa2e3076a3f17f4521b2cc41e258c446cdaa44742afe6e1b9fd5f82
 ```
 
+#### Remember cabals for auto-joining
+save a cabal to the config
+
+```
+cabal --save <key>
+```
+
+then connect to all of your saved cabals, by simply running `cabal`:
+
+```
+cabal
+```
+
+show saved cabals with `--cabals` and remove a saved cabal with `--forget`
+
+```
+cabal --cabals
+cabal --forget <key|alias>
+```
+
 #### Save an alias to a key
 
 create a local name for a key.

--- a/cli.js
+++ b/cli.js
@@ -160,15 +160,16 @@ if (args.clear) {
 
 if (args.forget) {
   let success = false
+  /* eslint no-inner-declarations: "off" */
   function forgetCabal (k) {
-    let index = config.cabals.indexOf(k)
+    const index = config.cabals.indexOf(k)
     if (index >= 0) {
-        config.cabals.splice(index, 1)
-        success = true
+      config.cabals.splice(index, 1)
+      success = true
     }
   }
-  if (config.aliases[args.forget]) { 
-    let aliasedKey = config.aliases[args.forget]
+  if (config.aliases[args.forget]) {
+    const aliasedKey = config.aliases[args.forget]
     success = true
     delete config.aliases[args.forget]
     // forget any potential reuses of the aliased key in config.cabals array
@@ -176,10 +177,10 @@ if (args.forget) {
   }
   // check if key is among saved cabals
   if (!success) forgetCabal(args.forget)
-  if (success) { 
+  if (success) {
     saveConfig(configFilePath, config)
-    console.log(`${args.forget} has been forgotten`) 
-  } else { console.log("no such cabal") }
+    console.log(`${args.forget} has been forgotten`)
+  } else { console.log('no such cabal') }
   process.exit(0)
 }
 
@@ -240,12 +241,12 @@ if (args.key) {
 // join and save the passed in cabal keys
 if (args.save) {
   cabalKeys = args._.map(getKey)
-  if (args.save.length  > 0) cabalKeys = cabalKeys.concat(getKey(args.save))
+  if (args.save.length > 0) cabalKeys = cabalKeys.concat(getKey(args.save))
   if (!cabalKeys.length) {
     console.log(`${chalk.magentaBright('cabal:')} error, need cabal keys to save. example:`)
     console.log(`${chalk.greenBright('cabal --save cabal://key')}`)
     process.exit(1)
-  } 
+  }
 
   config.cabals = config.cabals.concat(cabalKeys)
   saveConfig(configFilePath, config)
@@ -253,13 +254,13 @@ if (args.save) {
   if (cabalKeys.length === 1) {
     console.log(`${chalk.magentaBright('cabal:')} saved ${chalk.greenBright(cabalKeys[0])}`)
   } else {
-    console.log(`${chalk.magentaBright('cabal:')} saved the following keys:`) 
+    console.log(`${chalk.magentaBright('cabal:')} saved the following keys:`)
     cabalKeys.forEach((key) => { console.log(`${chalk.greenBright(key)}`) })
-  } 
+  }
   process.exit(0)
 }
 
-// try to initiate the frontend using either qr codes via webcam, using cabal keys passed via cli, 
+// try to initiate the frontend using either qr codes via webcam, using cabal keys passed via cli,
 // or starting an entirely new cabal per --new
 if (args.qr) {
   console.log('Cabal is looking for a QR code...')
@@ -278,7 +279,7 @@ if (args.qr) {
     console.error('Linux: sudo apt-get install fswebcam')
   })
 } else if (cabalKeys.length || args.new) {
-    start(cabalKeys, config.frontend)
+  start(cabalKeys, config.frontend)
 } else {
   // no keys, no qr, and not trying to start a new cabal => print help info
   process.stderr.write(usage)
@@ -303,7 +304,7 @@ function start (keys, frontendConfig) {
       console.error(`created the cabal: ${chalk.greenBright('cabal://' + client.getCurrentCabal().key)}`) // log to terminal output (stdout is occupied by interface)
       keys = [client.getCurrentCabal().key]
     }
-    // edgecase: if the config is empty we remember the first joined cabals in it 
+    // edgecase: if the config is empty we remember the first joined cabals in it
     if (!config.cabals.length) {
       config.cabals = keys
       saveConfig(configFilePath, config)

--- a/cli.js
+++ b/cli.js
@@ -32,14 +32,14 @@ var usage = `Usage
   Join a cabal by an alias:
     cabal <your saved --alias of a cabal>
 
-  Join a cabal by a QR code:
-    cabal --qr
-
-  Save a cabal to the config for next time:
+  Save a cabal, adding it to the list of cabals to autojoin:
     cabal --save cabal://key
 
-  Join all of your --save cabals by running just \`cabal\`:
+  Join all of your saved cabals by running just \`cabal\`:
     cabal
+
+  Join a cabal by a QR code:
+    cabal --qr
 
   Options:
     --seed    Start a headless seed for the specified cabal key


### PR DESCRIPTION
this pr adds the following flags:
`--save` saves a cabal to your config
`--cabals: lists the saved cabals in your config

--saved cabals are joined when cabal is invoked without arguments: `cabal`

the following flag has been removed:
`--join` previously joined the specific cabal while disregarding the config

the new behaviour is best explained by the examples below

```sh
# only join the passed in cabals
cabal cabal://key1 cabal://key2

# save the passed in cabal 
cabal --save cabal://key

# show saved cabals with --cabals
cabal --cabals

# remove a saved cabal using --forget
cabal --forget cabal://key

# join all of your saved cabals
cabal

# special case: if you don't have any saved cabals, we will save the first ones you run  e.g.
# if config empty, the following will persist the cabal to the config, first time only tho
cabal cabal://key # or
cabal --new
```

fixes #161 #158  also reverts PR #160 as it didn't work as expected. 

cc @tomquas here's the PR i promised! ^_^ it was a bit of an overhaul to get everything working inline with expectations. please check it out and let me know how things work!
