### PR TITLE
restore --nick to set nick on joining

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -256,6 +256,7 @@ function start (keys, frontendConfig) {
       console.error(`created the cabal: ${chalk.greenBright('cabal://' + client.getCurrentCabal().key)}`) // log to terminal output (stdout is occupied by interface)
       keys = [client.getCurrentCabal().key]
     }
+    if (args.nick && args.nick.length > 0) client.getCurrentCabal().publishNick(args.nick)
     if (!args.seed) { frontend({ client, frontendConfig }) } else {
       keys.forEach((k) => {
         console.log('Seeding', k)


### PR DESCRIPTION
per @substack's request, setting your nick when joining now works again using --nick

e.g. you can now do the following
```
cabal --new --seed --nick seedbot
```

which would
1. create a new cabal
2. join with rendering an ui (seed mode)
3. set the nickname to `seedbot`