### PR TITLE
UI Tweaks

### DIFF
--- a/neat-screen.js
+++ b/neat-screen.js
@@ -260,11 +260,12 @@ function NeatScreen (props) {
     self.loadChannel(channels[n])
   }
 
+  const scrollOffset = 11
   this.neat.input.on('pageup', () => {
-    this.state.messageScrollback += process.stdout.rows-10;
+    this.state.messageScrollback += process.stdout.rows-scrollOffset;
   });
   this.neat.input.on('pagedown', () => {
-    this.state.messageScrollback = Math.max(0, this.state.messageScrollback - (process.stdout.rows-10));
+    this.state.messageScrollback = Math.max(0, this.state.messageScrollback - (process.stdout.rows-scrollOffset));
   });
   this.neat.input.on('shift-pageup', () => {
     this.state.userScrollback = Math.max(0, this.state.userScrollback - (process.stdout.rows-9));

--- a/views.js
+++ b/views.js
@@ -31,38 +31,28 @@ function small (state) {
 
 function big (state) {
   var screen = []
-
   // title bar
   blit(screen, renderTitlebar(state, process.stdout.columns), 0, 0)
 
   if (state.cabals.length > 1) {
     // cabals pane
-    blit(screen, renderCabals(state, 6, process.stdout.rows - HEADER_ROWS), 0, 3)
-    blit(screen, renderVerticalLine('|', process.stdout.rows - 6, chalk.blue), 6, 3)
-    // channels pane
-    blit(screen, renderChannels(state, 18, process.stdout.rows - HEADER_ROWS), 7, 3)
-    blit(screen, renderVerticalLine('|', process.stdout.rows - 6, chalk.blue), 23, 3)
-    // chat messages
-    blit(screen, renderMessages(state, process.stdout.columns - (CHAN_COLS + 2) - (NICK_COLS + 2), process.stdout.rows - HEADER_ROWS), 24, 3)
-    // channel topic description
-    blit(screen, renderChannelTopic(state, process.stdout.columns - 23 - 17, process.stdout.rows - HEADER_ROWS), 24, 3)
-  } else {
-    // channels pane
-    blit(screen, renderChannels(state, CHAN_COLS, process.stdout.rows - HEADER_ROWS), 0, 3)
-    blit(screen, renderVerticalLine('|', process.stdout.rows - 6, chalk.blue), 16, 3)
-
-    // channel topic description
-    blit(screen, renderChannelTopic(state, process.stdout.columns - 16 - 17, process.stdout.rows - HEADER_ROWS), 17, 3)
-    // chat messages
-    blit(screen, renderMessages(state, process.stdout.columns - 17 - 17, process.stdout.rows - HEADER_ROWS), 17, 4)
+    blit(screen, renderCabals(state, 6, process.stdout.rows - HEADER_ROWS), 0, process.stdout.rows - 3)
   }
+  // channels listing
+  blit(screen, renderChannels(state, CHAN_COLS, process.stdout.rows - HEADER_ROWS), 0, 3)
+  blit(screen, renderVerticalLine('|', process.stdout.rows - 7, chalk.blue), 16, 3)
+
+  // channel topic description
+  blit(screen, renderChannelTopic(state, process.stdout.columns - 16 - 17, process.stdout.rows - HEADER_ROWS), 17, 3)
+  // chat messages
+  blit(screen, renderMessages(state, process.stdout.columns - 17 - 17, process.stdout.rows - HEADER_ROWS), 17, 4)
 
   // nicks pane
-  blit(screen, renderVerticalLine('|', process.stdout.rows - 6, chalk.blue), process.stdout.columns - 17, 3)
+  blit(screen, renderVerticalLine('|', process.stdout.rows - 7, chalk.blue), process.stdout.columns - 17, 3)
   blit(screen, renderNicks(state, NICK_COLS, process.stdout.rows - HEADER_ROWS), process.stdout.columns - 15, 3)
 
   // horizontal dividers
-  blit(screen, renderHorizontalLine('-', process.stdout.columns, chalk.blue), 0, process.stdout.rows - 3)
+  blit(screen, renderHorizontalLine('-', process.stdout.columns, chalk.blue), 0, process.stdout.rows - 4)
   blit(screen, renderHorizontalLine('-', process.stdout.columns, chalk.blue), 0, 2)
 
   // user input prompt
@@ -91,21 +81,20 @@ function renderTitlebar (state, width) {
 }
 
 function renderCabals (state, width, height) {
-  return state.cabals
-    .map(function (cabal, idx) {
+   return ["[" + state.cabals.map(function (cabal, idx) {
       var key = cabal
-      var keyTruncated = key.substring(0, 4)
+      var keyTruncated = key.substring(0, 6)
+      let unread = ""
       if (state.cabal.key === key) {
-        var fill = ' '
         if (state.selectedWindowPane === 'cabals') {
-          return '>' + chalk.bgBlue(keyTruncated + fill)
+          return `(${unread}${chalk.bgBlue(keyTruncated)})`
         } else {
-          return ' ' + chalk.bgBlue(keyTruncated + fill)
+          return `(${unread}${chalk.cyan(keyTruncated)})`
         }
       } else {
-        return ' ' + chalk.white(keyTruncated)
+        return `${unread}${chalk.white(keyTruncated)}`
       }
-    })
+    }).join(" ") + "]"]
 }
 
 function renderChannels (state, width, height) {

--- a/views.js
+++ b/views.js
@@ -81,20 +81,20 @@ function renderTitlebar (state, width) {
 }
 
 function renderCabals (state, width, height) {
-   return ["[" + state.cabals.map(function (cabal, idx) {
+   return ['[' + state.cabals.map(function (cabal, idx) {
       var key = cabal
       var keyTruncated = key.substring(0, 6)
-      let unread = ""
+      // if we're dealing with the active/focused cabal
       if (state.cabal.key === key) {
         if (state.selectedWindowPane === 'cabals') {
-          return `(${unread}${chalk.bgBlue(keyTruncated)})`
+          return `(${chalk.bgBlue(keyTruncated)})`
         } else {
-          return `(${unread}${chalk.cyan(keyTruncated)})`
+          return `(${chalk.cyan(keyTruncated)})`
         }
       } else {
-        return `${unread}${chalk.white(keyTruncated)}`
+        return chalk.white(keyTruncated)
       }
-    }).join(" ") + "]"]
+    }).join(' ') + ']']
 }
 
 function renderChannels (state, width, height) {

--- a/views.js
+++ b/views.js
@@ -45,22 +45,16 @@ function big (state) {
     // chat messages
     blit(screen, renderMessages(state, process.stdout.columns - (CHAN_COLS + 2) - (NICK_COLS + 2), process.stdout.rows - HEADER_ROWS), 24, 3)
     // channel topic description
-    if (state.topic) {
-      blit(screen, renderChannelTopic(state, process.stdout.columns - 23 - 17, process.stdout.rows - HEADER_ROWS), 24, 3)
-    }
+    blit(screen, renderChannelTopic(state, process.stdout.columns - 23 - 17, process.stdout.rows - HEADER_ROWS), 24, 3)
   } else {
     // channels pane
     blit(screen, renderChannels(state, CHAN_COLS, process.stdout.rows - HEADER_ROWS), 0, 3)
     blit(screen, renderVerticalLine('|', process.stdout.rows - 6, chalk.blue), 16, 3)
 
-    var chatY = 3
     // channel topic description
-    if (state.topic) {
-      blit(screen, renderChannelTopic(state, process.stdout.columns - 16 - 17, process.stdout.rows - HEADER_ROWS), 17, 3)
-      chatY++
-    }
+    blit(screen, renderChannelTopic(state, process.stdout.columns - 16 - 17, process.stdout.rows - HEADER_ROWS), 17, 3)
     // chat messages
-    blit(screen, renderMessages(state, process.stdout.columns - 17 - 17, process.stdout.rows - HEADER_ROWS), 17, chatY)
+    blit(screen, renderMessages(state, process.stdout.columns - 17 - 17, process.stdout.rows - HEADER_ROWS), 17, 4)
   }
 
   // nicks pane
@@ -185,7 +179,7 @@ function renderNicks (state, width, height) {
 
 function renderChannelTopic (state, width, height) {
   var topic = state.topic || state.channel
-  var line = '➤ ' + topic
+  var line = topic ? '➤ ' + topic : ""
   line = line.substring(0, width - 1)
   if (line.length === width - 1) {
     line = line.substring(0, line.length - 1) + '…'


### PR DESCRIPTION
This PR:
* introduces a new layout when joined to many cabals (see images below)
* tweaks the amount of messages scrolled of the newly landed #172 (increases the amount by 1, fixing a problem i had of there being no overlap in messages for my terminal)
* persists the blue topic bar for all channels, regardless of if a topic is set or not

as a result of the new cabals layout this fixes #174. the amount of complexity in `views.js` has also been reduced, as there is less variable state wrt blitting (motd existing or not, cabals pane taking up space or not).

new layout when channel pane is focused: 
![image](https://user-images.githubusercontent.com/3862362/79894752-33166f80-8406-11ea-9a3e-b2c8d52e99d8.png)

and when new cabal pane is focused:
![image](https://user-images.githubusercontent.com/3862362/79894798-475a6c80-8406-11ea-95c9-8fd6e68ea8c4.png)



@noffle also had a really nice idea of tree layouts which (if i understood the idea correctly!!) would basically look like the below, but with cabal names at the top level, channel names indented (and no dots)
![image](https://user-images.githubusercontent.com/3862362/79894683-1bd78200-8406-11ea-9638-856df41cd2e1.png))
