### PR TITLE
introduce pubkey id-suffixes, toggled via /ids command

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ ctrl+{n,p}
 &nbsp;&nbsp;&nbsp;&nbsp;select channels  1-9  
 `alt-n`  
 &nbsp;&nbsp;&nbsp;&nbsp;tab between the cabals & channels panes 
+`alt-l`  
+&nbsp;&nbsp;&nbsp;&nbsp;tab toggle id suffixes on/off
 
 #### Configuration
 

--- a/commands.js
+++ b/commands.js
@@ -3,13 +3,20 @@ var chalk = require('chalk')
 
 function Commander (view, client) {
   if (!(this instanceof Commander)) return new Commander(view, client)
+  this._hasListeners = {}
   this.client = client
-  this.cabal = client.getCurrentCabal()
+  this.cabal = null
+  this.setActiveCabal(client.getCurrentCabal())
   this.channel = '!status'
   this.view = view
   this.pattern = (/^\/(\w*)\s*(.*)/)
   this.history = []
   this.historyIndex = -1 // negative: new msg. >=0: index from the last item
+}
+
+Commander.prototype.setActiveCabal = function (cabal) {
+  this.cabal = cabal
+  if (this._hasListeners[cabal.key]) return
   var log = this.logger()
   this.cabal.on('info', (msg) => {
     var txt = typeof msg === 'string' ? msg : (msg && msg.text ? msg.text : '')
@@ -18,6 +25,7 @@ function Commander (view, client) {
   this.cabal.on('error', (err) => {
     log(chalk.bold(chalk.red('! ' + util.sanitizeString(String(err)))))
   })
+  this._hasListeners[cabal.key] = true
 }
 
 // for use when writing multiple logs within short intervals

--- a/neat-screen.js
+++ b/neat-screen.js
@@ -382,7 +382,7 @@ NeatScreen.prototype.processMessages = function (opts, cb) {
 NeatScreen.prototype.showCabal = function (cabal) {
   this.state.cabal = this.client.focusCabal(cabal)
   this.registerUpdateHandler(this.state.cabal)
-  this.commander.cabal = this.state.cabal
+  this.commander.setActiveCabal(this.state.cabal)
   this.client.focusChannel()
   this.bus.emit('render')
 }
@@ -467,7 +467,12 @@ NeatScreen.prototype.formatMessage = function (msg) {
     var color = keyToColour(msg.key) || colours[5]
 
     var timestamp = `${chalk.dim(formatTime(msg.value.timestamp, this.config.messageTimeformat))}`
-    var authorText = `${chalk.dim('<')}${highlight ? chalk.whiteBright(author) : chalk[color](author)}${chalk.dim('>')}`
+    if (this.state.cabal.showIds) {
+      var pubid = authorSource.key.slice(0, 9) 
+      var authorText = `${chalk.dim('<')}${highlight ? chalk.whiteBright(author): chalk[color](author)}${chalk.dim(".")}${chalk.cyan(pubid)}${chalk.dim('>')}`
+    } else {
+      var authorText = `${chalk.dim('<')}${highlight ? chalk.whiteBright(author): chalk[color](author)}${chalk.dim('>')}`
+    }
     if (msg.value.type === 'status') {
       highlight = false // never highlight from status
       authorText = `${chalk.dim('-')}${highlight ? chalk.whiteBright(author) : chalk.cyan('status')}${chalk.dim('-')}`

--- a/neat-screen.js
+++ b/neat-screen.js
@@ -196,6 +196,8 @@ function NeatScreen (props) {
   this.neat.input.on('alt-8', () => { setChannelByIndex(7) })
   this.neat.input.on('alt-9', () => { setChannelByIndex(8) })
   this.neat.input.on('alt-0', () => { setChannelByIndex(9) })
+  this.neat.input.on('alt-l', () => { this.commander.process("/ids") })
+
 
   this.neat.input.on('keypress', (ch, key) => {
     if (!key || !key.name) return

--- a/neat-screen.js
+++ b/neat-screen.js
@@ -338,7 +338,7 @@ NeatScreen.prototype.initializeCabalClient = function () {
   this.state.userScrollback = 0
   var counter = 0
   this.client.getCabalKeys().forEach((key) => {
-    welcomeMessage.map((m) => this.client.getDetails(key).addStatusMessage({ timestamp: Date.now() + counter++, text: m }))
+    welcomeMessage.map((m) => this.client.getDetails(key).addStatusMessage({ timestamp: Date.now() + counter++, text: m }), "!status")
   })
   this.registerUpdateHandler(details)
   this.loadChannel('!status')

--- a/neat-screen.js
+++ b/neat-screen.js
@@ -481,7 +481,7 @@ NeatScreen.prototype.formatMessage = function (msg) {
     // if there is a collision in the first 4 characters of a pub key in the cabal, expand it to the first 9
     const pubid = this.state.collision[authorSource.key.slice(0, 4)] ? authorSource.key.slice(0, 9) : authorSource.key.slice(0, 4) 
     if (this.state.cabal.showIds) {
-      authorText = `${chalk.dim('<')}${highlight ? chalk.whiteBright(author): chalk[color](author)}${chalk.dim(".")}${chalk.cyan(pubid)}${chalk.dim('>')}`
+      authorText = `${chalk.dim('<')}${highlight ? chalk.whiteBright(author): chalk[color](author)}${chalk.dim(".")}${chalk.inverse(chalk.cyan(pubid))}${chalk.dim('>')}`
     } else {
       authorText = `${chalk.dim('<')}${highlight ? chalk.whiteBright(author): chalk[color](author)}${chalk.dim('>')}`
     }
@@ -494,7 +494,7 @@ NeatScreen.prototype.formatMessage = function (msg) {
     var emote = (msg.value.type === 'chat/emote')
 
     if (emote) {
-      authorText = `${chalk.white(author)}${this.state.cabal.showIds ? chalk.dim(".") + chalk.cyan(pubid) : ""}`
+      authorText = `${chalk.white(author)}${this.state.cabal.showIds ? chalk.dim(".") + chalk.inverse(chalk.cyan(pubid)) : ""}`
       content = `${chalk.dim(msgtxt)}`
     }
 

--- a/neat-screen.js
+++ b/neat-screen.js
@@ -196,8 +196,7 @@ function NeatScreen (props) {
   this.neat.input.on('alt-8', () => { setChannelByIndex(7) })
   this.neat.input.on('alt-9', () => { setChannelByIndex(8) })
   this.neat.input.on('alt-0', () => { setChannelByIndex(9) })
-  this.neat.input.on('alt-l', () => { this.commander.process("/ids") })
-
+  this.neat.input.on('alt-l', () => { this.commander.process('/ids') })
 
   this.neat.input.on('keypress', (ch, key) => {
     if (!key || !key.name) return
@@ -264,17 +263,17 @@ function NeatScreen (props) {
 
   const scrollOffset = 11
   this.neat.input.on('pageup', () => {
-    this.state.messageScrollback += process.stdout.rows-scrollOffset;
-  });
+    this.state.messageScrollback += process.stdout.rows - scrollOffset
+  })
   this.neat.input.on('pagedown', () => {
-    this.state.messageScrollback = Math.max(0, this.state.messageScrollback - (process.stdout.rows-scrollOffset));
-  });
+    this.state.messageScrollback = Math.max(0, this.state.messageScrollback - (process.stdout.rows - scrollOffset))
+  })
   this.neat.input.on('shift-pageup', () => {
-    this.state.userScrollback = Math.max(0, this.state.userScrollback - (process.stdout.rows-9));
-  });
+    this.state.userScrollback = Math.max(0, this.state.userScrollback - (process.stdout.rows - 9))
+  })
   this.neat.input.on('shift-pagedown', () => {
-    this.state.userScrollback += process.stdout.rows-9;
-  });
+    this.state.userScrollback += process.stdout.rows - 9
+  })
 
   this.neat.use((state, bus) => {
     state.neat = this.neat
@@ -340,7 +339,7 @@ NeatScreen.prototype.initializeCabalClient = function () {
   this.state.userScrollback = 0
   var counter = 0
   this.client.getCabalKeys().forEach((key) => {
-    welcomeMessage.map((m) => this.client.getDetails(key).addStatusMessage({ timestamp: Date.now() + counter++, text: m }), "!status")
+    welcomeMessage.map((m) => this.client.getDetails(key).addStatusMessage({ timestamp: Date.now() + counter++, text: m }), '!status')
   })
   this.registerUpdateHandler(details)
   this.loadChannel('!status')
@@ -351,10 +350,10 @@ NeatScreen.prototype._updateCollisions = function () {
   this.state.collision = {}
   const userKeys = Object.keys(this.state.cabal.getUsers())
   userKeys.forEach((u) => {
-	const collision = typeof this.state.collision[u.slice(0,4)] === "undefined" ? false : true
-    // if there is a collision in the first 4 chars of a pub key in the cabal, 
+    const collision = typeof this.state.collision[u.slice(0, 4)] !== 'undefined'
+    // if there is a collision in the first 4 chars of a pub key in the cabal,
     // expand it to the largest length that lets us disambiguate between the colliding ids
-    this.state.collision[u.slice(0,4)] = { collision, idlen: (collision ? util.unambiguous(userKeys, u) : 4) }
+    this.state.collision[u.slice(0, 4)] = { collision, idlen: (collision ? util.unambiguous(userKeys, u) : 4) }
   })
 }
 
@@ -477,6 +476,7 @@ NeatScreen.prototype.formatMessage = function (msg) {
     if (msg.value.type !== 'status') {
       msgtxt = util.sanitizeString(msgtxt)
     }
+    var content = markdown(msgtxt)
 
     if (localNick.length > 0 && msgtxt.indexOf(localNick) > -1 && author !== localNick) { highlight = true }
 
@@ -488,25 +488,24 @@ NeatScreen.prototype.formatMessage = function (msg) {
       highlight = false // never highlight from status
       authorText = `${chalk.dim('-')}${highlight ? chalk.whiteBright(author) : chalk.cyan('status')}${chalk.dim('-')}`
     } else {
-      /* a user wrote a message, not the !status virtual message*/
+      /* a user wrote a message, not the !status virtual message */
 
       // if there is a collision in the first 4 characters of a pub key in the cabal, expand it to the largest length that
       // lets us disambiguate between the two ids in the collision
       const collision = this.state.collision[authorSource.key.slice(0, 4)]
-      const pubid = authorSource.key.slice(0, collision.idlen) 
+      const pubid = authorSource.key.slice(0, collision.idlen)
       if (this.state.cabal.showIds) {
-        authorText = `${chalk.dim('<')}${highlight ? chalk.whiteBright(author): chalk[color](author)}${chalk.dim(".")}${chalk.inverse(chalk.cyan(pubid))}${chalk.dim('>')}`
+        authorText = `${chalk.dim('<')}${highlight ? chalk.whiteBright(author) : chalk[color](author)}${chalk.dim('.')}${chalk.inverse(chalk.cyan(pubid))}${chalk.dim('>')}`
       } else {
-        authorText = `${chalk.dim('<')}${highlight ? chalk.whiteBright(author): chalk[color](author)}${chalk.dim('>')}`
+        authorText = `${chalk.dim('<')}${highlight ? chalk.whiteBright(author) : chalk[color](author)}${chalk.dim('>')}`
       }
 
       var emote = (msg.value.type === 'chat/emote')
       if (emote) {
-        authorText = `${chalk.white(author)}${this.state.cabal.showIds ? chalk.dim(".") + chalk.inverse(chalk.cyan(pubid)) : ""}`
+        authorText = `${chalk.white(author)}${this.state.cabal.showIds ? chalk.dim('.') + chalk.inverse(chalk.cyan(pubid)) : ''}`
         content = `${chalk.dim(msgtxt)}`
       }
     }
-    var content = markdown(msgtxt)
 
     if (msg.value.type === 'chat/topic') {
       content = `${chalk.dim(`* sets the topic to ${chalk.cyan(msgtxt)}`)}`

--- a/neat-screen.js
+++ b/neat-screen.js
@@ -467,11 +467,12 @@ NeatScreen.prototype.formatMessage = function (msg) {
     var color = keyToColour(msg.key) || colours[5]
 
     var timestamp = `${chalk.dim(formatTime(msg.value.timestamp, this.config.messageTimeformat))}`
+    let authorText
+    const pubid = authorSource.key.slice(0, 9) 
     if (this.state.cabal.showIds) {
-      var pubid = authorSource.key.slice(0, 9) 
-      var authorText = `${chalk.dim('<')}${highlight ? chalk.whiteBright(author): chalk[color](author)}${chalk.dim(".")}${chalk.cyan(pubid)}${chalk.dim('>')}`
+      authorText = `${chalk.dim('<')}${highlight ? chalk.whiteBright(author): chalk[color](author)}${chalk.dim(".")}${chalk.cyan(pubid)}${chalk.dim('>')}`
     } else {
-      var authorText = `${chalk.dim('<')}${highlight ? chalk.whiteBright(author): chalk[color](author)}${chalk.dim('>')}`
+      authorText = `${chalk.dim('<')}${highlight ? chalk.whiteBright(author): chalk[color](author)}${chalk.dim('>')}`
     }
     if (msg.value.type === 'status') {
       highlight = false // never highlight from status
@@ -482,7 +483,7 @@ NeatScreen.prototype.formatMessage = function (msg) {
     var emote = (msg.value.type === 'chat/emote')
 
     if (emote) {
-      authorText = `${chalk.white(author)}`
+      authorText = `${chalk.white(author)}${this.state.cabal.showIds ? chalk.dim(".") + chalk.cyan(pubid) : ""}`
       content = `${chalk.dim(msgtxt)}`
     }
 

--- a/neat-screen.js
+++ b/neat-screen.js
@@ -337,7 +337,9 @@ NeatScreen.prototype.initializeCabalClient = function () {
   this.state.messageScrollback = 0
   this.state.userScrollback = 0
   var counter = 0
-  welcomeMessage.map((m) => this.client.addStatusMessage({ timestamp: Date.now() + counter++, text: m }))
+  this.client.getCabalKeys().forEach((key) => {
+    welcomeMessage.map((m) => this.client.getDetails(key).addStatusMessage({ timestamp: Date.now() + counter++, text: m }))
+  })
   this.registerUpdateHandler(details)
   this.loadChannel('!status')
 }

--- a/neat-screen.js
+++ b/neat-screen.js
@@ -351,7 +351,7 @@ NeatScreen.prototype._updateCollisions = function () {
   this.state.collision = {}
   const userKeys = Object.keys(this.state.cabal.getUsers())
   userKeys.forEach((u) => {
-    const collision = typeof this.state.collision[u.slice(0,4)] === "undefined" ? false : true
+	const collision = typeof this.state.collision[u.slice(0,4)] === "undefined" ? false : true
     // if there is a collision in the first 4 chars of a pub key in the cabal, 
     // expand it to the largest length that lets us disambiguate between the colliding ids
     this.state.collision[u.slice(0,4)] = { collision, idlen: (collision ? util.unambiguous(userKeys, u) : 4) }
@@ -477,7 +477,6 @@ NeatScreen.prototype.formatMessage = function (msg) {
     if (msg.value.type !== 'status') {
       msgtxt = util.sanitizeString(msgtxt)
     }
-    var content = markdown(msgtxt)
 
     if (localNick.length > 0 && msgtxt.indexOf(localNick) > -1 && author !== localNick) { highlight = true }
 
@@ -496,9 +495,9 @@ NeatScreen.prototype.formatMessage = function (msg) {
       const collision = this.state.collision[authorSource.key.slice(0, 4)]
       const pubid = authorSource.key.slice(0, collision.idlen) 
       if (this.state.cabal.showIds) {
-        authorText = `${chalk.dim('<')}${highlight ? chalk.whiteBright(author) : chalk[color](author)}${chalk.dim(".")}${chalk.inverse(chalk.cyan(pubid))}${chalk.dim('>')}`
+        authorText = `${chalk.dim('<')}${highlight ? chalk.whiteBright(author): chalk[color](author)}${chalk.dim(".")}${chalk.inverse(chalk.cyan(pubid))}${chalk.dim('>')}`
       } else {
-        authorText = `${chalk.dim('<')}${highlight ? chalk.whiteBright(author) : chalk[color](author)}${chalk.dim('>')}`
+        authorText = `${chalk.dim('<')}${highlight ? chalk.whiteBright(author): chalk[color](author)}${chalk.dim('>')}`
       }
 
       var emote = (msg.value.type === 'chat/emote')
@@ -507,6 +506,7 @@ NeatScreen.prototype.formatMessage = function (msg) {
         content = `${chalk.dim(msgtxt)}`
       }
     }
+    var content = markdown(msgtxt)
 
     if (msg.value.type === 'chat/topic') {
       content = `${chalk.dim(`* sets the topic to ${chalk.cyan(msgtxt)}`)}`

--- a/package-lock.json
+++ b/package-lock.json
@@ -540,9 +540,9 @@
       "dev": true
     },
     "cabal-client": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cabal-client/-/cabal-client-4.0.0.tgz",
-      "integrity": "sha512-J9EWrGGhI/9H9NSBx/VGgxhW9B4vmcO+qCk4iFqR+3RSFXp75X1ftwh/+mCB4z2kuY4wWZLrcNWgFngrZDcHXw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cabal-client/-/cabal-client-4.1.0.tgz",
+      "integrity": "sha512-sTuuUcjUYL/WgO4vipBzOSQpiJbO1ZGHw6EV+3QtBCLohms2lpUwbwhw3ZZZ4nO1CwLY5OAZDTPgqNLtxbDIfQ==",
       "requires": {
         "cabal-core": "^10.0.0",
         "collect-stream": "^1.2.1",
@@ -567,16 +567,16 @@
       }
     },
     "cabal-core": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/cabal-core/-/cabal-core-10.0.0.tgz",
-      "integrity": "sha512-AqWx4EOENbAoTS6jOtxbVChpZ7a0+0f4IWJK4L2X9eiD1pk3dTqhT9Oa8s3k13Pysg12jRFbqg+7BIKHjZ5kOA==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/cabal-core/-/cabal-core-10.0.1.tgz",
+      "integrity": "sha512-QcBsfYRsoIhZ1zBH4xfve2twA6u3QcuqeaOHvXioL/V7ZNoTASFnOnI1blHMToXKu2Sao/vArUxh6mlteEw+Qg==",
       "requires": {
         "charwise": "^3.0.1",
         "concat-stream": "^2.0.0",
         "dat-encoding": "^5.0.1",
         "debug": "^4.1.1",
         "hypercore-crypto": "^1.0.0",
-        "hyperswarm": "^2.8.0",
+        "hyperswarm": "^2.13.0",
         "inherits": "^2.0.4",
         "kappa-core": "^6.0.0",
         "kappa-view-level": "^2.0.1",
@@ -724,9 +724,9 @@
       "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
     },
     "codecs": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/codecs/-/codecs-2.0.0.tgz",
-      "integrity": "sha512-WXvpJRAgc693oqYvZte9uYEiL5YHtfrxyEq12uVny9oBJ1k37zSva5vVz7trsnt6R9Y15hEgOSC7VFZT2pfYnA=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/codecs/-/codecs-2.1.0.tgz",
+      "integrity": "sha512-nSWYToViFEpZXOxhtMQ6IDs76TN9xKIkHOu1KCr/iFiBcgzKuY1AFPZktuXN8r82FbZ/TXP9fwITszLgcp3eQg=="
     },
     "collect-stream": {
       "version": "1.2.1",
@@ -1035,9 +1035,9 @@
       "dev": true
     },
     "dht-rpc": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/dht-rpc/-/dht-rpc-4.8.1.tgz",
-      "integrity": "sha512-5x+1nrAXIOaclICKI3hj1LpP2SW/aDw/Rzz76KWZNCtmqhPkxIHMdqLPL2ozw4DuqX2Uq/Wr9FE5dSFbNt/YyA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/dht-rpc/-/dht-rpc-4.9.0.tgz",
+      "integrity": "sha512-FvIdg9WXJ+n3nrlg965oP51qg8pssBAhV810VAi66pib+MHKvbPZYcceD9ZQgSfPCaF1YuwhEJIz3dfnT0drYA==",
       "requires": {
         "codecs": "^2.0.0",
         "ipv4-peers": "^2.0.0",
@@ -2849,9 +2849,9 @@
       "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
     },
     "materialized-group-auth": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/materialized-group-auth/-/materialized-group-auth-1.1.3.tgz",
-      "integrity": "sha512-VlmHVEdzogn2FtyufZ9glzg1mj/SOHRFTqGMt5Bw9O2gwysQdKRvRECRSjiLF0WEfSgR98/01HymMHBjZZaZSA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/materialized-group-auth/-/materialized-group-auth-1.2.0.tgz",
+      "integrity": "sha512-fDSF+vLqJcezJknadEQAKSUVJBzgswYFfbPIrSrhnKsmeX1PAbUx6YVwf0sYpl/aizm6uiaoZK1rfRg0qmC57A==",
       "requires": {
         "collect-stream": "^1.2.1",
         "duplexify": "^4.0.0",
@@ -3102,9 +3102,9 @@
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
     "mkdirp-classic": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.2.tgz",
-      "integrity": "sha512-ejdnDQcR75gwknmMw/tx02AuRs8jCtqFoFqDZMjiNxsu85sRIJVXDKHuLYvUUPRBUtV2FpSZa9bL1BUa3BdR2g=="
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "mocha": {
       "version": "7.1.1",
@@ -3314,9 +3314,9 @@
       "dev": true
     },
     "mutexify": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mutexify/-/mutexify-1.2.0.tgz",
-      "integrity": "sha512-oprzxd2zhfrJqEuB98qc1dRMMonClBQ57UPDjnbcrah4orEMTq1jq3+AcdFe5ePzdbJXI7zmdhfftIdMnhYFoQ=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/mutexify/-/mutexify-1.3.0.tgz",
+      "integrity": "sha512-WNPlgZ3AHETGSa4jeRP4aW6BPQ/a++MwoMFFIgrDg80+m70mbxuNOrevANfBDmur82zxTFAY3OwvMAvqrkV2sA=="
     },
     "nan": {
       "version": "2.14.1",
@@ -3506,9 +3506,9 @@
       }
     },
     "node-gyp-build": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.1.tgz",
-      "integrity": "sha512-XyCKXsqZfLqHep1hhsMncoXuUNt/cXCjg1+8CLbu69V1TKuPiOeSGbL9n+k/ByKH8UT0p4rdIX8XkTRZV0i7Sw=="
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.2.tgz",
+      "integrity": "sha512-Lqh7mrByWCM8Cf9UPqpeoVBBo5Ugx+RKu885GAzmLBVYjeywScxHXPGLa4JfYNZmcNGwzR0Glu5/9GaQZMFqyA=="
     },
     "noise-protocol": {
       "version": "1.0.0",
@@ -5261,9 +5261,9 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utp-native": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/utp-native/-/utp-native-2.1.7.tgz",
-      "integrity": "sha512-PQmXCdZOkmADtIqmhoiFEIdNlvkPouO8ktXqThFDBAt850B752bjQMF5KAJeMBJ5gzuI70ZiP9Qsr9mwCwzSyg==",
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/utp-native/-/utp-native-2.1.10.tgz",
+      "integrity": "sha512-VTjBvb/uE9gYqx2NGVPtAWhqv9itieW+wJceJg5G6Cl/2kBCnHDaFafw3fNgCvii7meTpC4AoZfy6OG0pnuQ/Q==",
       "requires": {
         "napi-macros": "^2.0.0",
         "node-gyp-build": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "ansi-escapes": "^4.3.1",
-    "cabal-client": "^4.0.0",
+    "cabal-client": "^4.1.0",
     "chalk": "^4.0.0",
     "js-yaml": "^3.13.1",
     "minimist": "^1.2.5",

--- a/util.js
+++ b/util.js
@@ -95,6 +95,21 @@ function rightAlignText (text, width) {
   return lspace + text
 }
 
+// find the shortest length that is unambiguous when matching `key` for each entry in `keys`
+function unambiguous (keys, key) {
+  var n = 0
+  for (var i = 0; i < keys.length; i++) {
+    var k = keys[i]
+    if (key === k) continue
+    var len = Math.min(k.length, key.length)
+    for (var j = 0; j < len; j++) {
+      if (key.charAt(j) !== k.charAt(j)) break
+      n = Math.max(n,j)
+    }
+  }
+  return n
+}
+
 function wrapStatusMsg (m) {
   return {
     key: 'status',
@@ -117,4 +132,4 @@ function cmpUser (a, b) {
   return a.key < b.key ? -1 : 1
 }
 
-module.exports = { cmpUser, log, wrapAnsi, strlenAnsi, centerText, rightAlignText, wrapStatusMsg, sanitizeString }
+module.exports = { cmpUser, log, wrapAnsi, strlenAnsi, centerText, rightAlignText, wrapStatusMsg, sanitizeString, unambiguous }

--- a/util.js
+++ b/util.js
@@ -103,11 +103,11 @@ function unambiguous (keys, key) {
     if (key === k) continue
     var len = Math.min(k.length, key.length)
     for (var j = 0; j < len; j++) {
-      n = Math.max(n,j)
+      n = Math.max(n, j)
       if (key.charAt(j) !== k.charAt(j)) break
     }
   }
-  return n+1
+  return n + 1
 }
 
 function wrapStatusMsg (m) {

--- a/util.js
+++ b/util.js
@@ -103,11 +103,11 @@ function unambiguous (keys, key) {
     if (key === k) continue
     var len = Math.min(k.length, key.length)
     for (var j = 0; j < len; j++) {
-      if (key.charAt(j) !== k.charAt(j)) break
       n = Math.max(n,j)
+      if (key.charAt(j) !== k.charAt(j)) break
     }
   }
-  return n
+  return n+1
 }
 
 function wrapStatusMsg (m) {

--- a/views.js
+++ b/views.js
@@ -81,20 +81,20 @@ function renderTitlebar (state, width) {
 }
 
 function renderCabals (state, width, height) {
-   return ['[' + state.cabals.map(function (cabal, idx) {
-      var key = cabal
-      var keyTruncated = key.substring(0, 6)
-      // if we're dealing with the active/focused cabal
-      if (state.cabal.key === key) {
-        if (state.selectedWindowPane === 'cabals') {
-          return `(${chalk.bgBlue(keyTruncated)})`
-        } else {
-          return `(${chalk.cyan(keyTruncated)})`
-        }
+  return ['[' + state.cabals.map(function (cabal, idx) {
+    var key = cabal
+    var keyTruncated = key.substring(0, 6)
+    // if we're dealing with the active/focused cabal
+    if (state.cabal.key === key) {
+      if (state.selectedWindowPane === 'cabals') {
+        return `(${chalk.bgBlue(keyTruncated)})`
       } else {
-        return chalk.white(keyTruncated)
+        return `(${chalk.cyan(keyTruncated)})`
       }
-    }).join(' ') + ']']
+    } else {
+      return chalk.white(keyTruncated)
+    }
+  }).join(' ') + ']']
 }
 
 function renderChannels (state, width, height) {
@@ -131,44 +131,44 @@ function renderHorizontalLine (chr, width, chlk) {
 
 function renderNicks (state, width, height) {
   // All known users
-  var users = state.cabal.getChannelMembers();
+  var users = state.cabal.getChannelMembers()
   users = Object.keys(users)
     .map(key => users[key])
-    .sort(util.cmpUser);
+    .sort(util.cmpUser)
 
   // Check which users are online
-  var onlines = {};
+  var onlines = {}
   users = users.map(function (user) {
-    var name = '';
-    if (user && user.name) name += util.sanitizeString(user.name).slice(0, width);
-    else name += user.key.slice(0, Math.min(8, width));
-    if (user.online) onlines[name] = name in onlines ? onlines[name] + 1 : 1;
-    return name;
-  });
+    var name = ''
+    if (user && user.name) name += util.sanitizeString(user.name).slice(0, width)
+    else name += user.key.slice(0, Math.min(8, width))
+    if (user.online) onlines[name] = name in onlines ? onlines[name] + 1 : 1
+    return name
+  })
 
   // Count how many occurances of same nickname there are
-  var nickCount = {};
-  users.forEach(function (u) { nickCount[u] = u in nickCount ? nickCount[u] + 1 : 1; });
+  var nickCount = {}
+  users.forEach(function (u) { nickCount[u] = u in nickCount ? nickCount[u] + 1 : 1 })
 
   // Format nicks with online state and possible duplication
   var formattedNicks = users.filter((u, i, arr) => arr.indexOf(u) === i).map((u) => {
-      if (nickCount[u] === 1) return u in onlines ? chalk.bold(u) : chalk.gray(u);
-      var dupecount = ` (${nickCount[u]})`;
-      var name = u.slice(0, 15 - dupecount.length);
-      return (u in onlines ? chalk.bold(name) : chalk.gray(name)) + chalk.green(dupecount);
-  });
+    if (nickCount[u] === 1) return u in onlines ? chalk.bold(u) : chalk.gray(u)
+    var dupecount = ` (${nickCount[u]})`
+    var name = u.slice(0, 15 - dupecount.length)
+    return (u in onlines ? chalk.bold(name) : chalk.gray(name)) + chalk.green(dupecount)
+  })
 
   // Scrolling Rendering
-  state.userScrollback = Math.min(state.userScrollback, formattedNicks.length - height);
-  if (formattedNicks.length < height) state.userScrollback = 0;
-  var nickBlock = formattedNicks.slice(state.userScrollback, state.userScrollback + height);
+  state.userScrollback = Math.min(state.userScrollback, formattedNicks.length - height)
+  if (formattedNicks.length < height) state.userScrollback = 0
+  var nickBlock = formattedNicks.slice(state.userScrollback, state.userScrollback + height)
 
-  return nickBlock;
+  return nickBlock
 }
 
 function renderChannelTopic (state, width, height) {
   var topic = state.topic || state.channel
-  var line = topic ? '➤ ' + topic : ""
+  var line = topic ? '➤ ' + topic : ''
   line = line.substring(0, width - 1)
   if (line.length === width - 1) {
     line = line.substring(0, line.length - 1) + '…'


### PR DESCRIPTION
this PR adds support for the /ids command (added in a PR to cabal-client). 

when `/ids` is run, the cli shows nicknames appended with the first 9 characters of their public key, see the image below.

9 characters was chosen as a long enough identifier that brute forcing is discouraged (based on numbers from [lachenmayer/vanity-dat](https://github.com/lachenmayer/vanity-dat)), even if it is a bit garish. 

the intent is to run with `/ids` on when you want to uniquely identify someone, e.g. when initiating a new PM or issuing a moderation action such as adding someone as a moderator, or banning them.

![image](https://user-images.githubusercontent.com/3862362/81003093-9b277580-8e4a-11ea-9f2f-ca2551ffb356.png)

p.s. the PR also fixes command output not being visible when joined to multiple cabals at the same time (only the first joined cabal would have its input shown)

### TODO
* ~~make an attempt at [arbitrary collisions](https://gist.github.com/substack/ad6115880acb6714cad8e1f0997beb8a)~~
* ~~invert bg colour of id segment~~
* ~~add a keybinding (`alt-i`/`alt-l`?) for toggling /ids on off~~
