### PR TITLE
initialize state.collision

### DIFF
--- a/neat-screen.js
+++ b/neat-screen.js
@@ -287,6 +287,7 @@ function NeatScreen (props) {
     state.windowPanes = [state.selectedWindowPane]
     state.config = this.config
     state.messageTimeLength = strftime(this.config.messageTimeformat, new Date()).length
+    state.collision = {}
     this.state = state
 
     Object.defineProperty(this.state, 'cabal', {


### PR DESCRIPTION
It's possible for state.collision to be checked before an update comes in that initializes the value, which can crash the program.