### PR TITLE
fixes to look better with a light bg

### DIFF
--- a/neat-screen.js
+++ b/neat-screen.js
@@ -558,7 +558,7 @@ var colours = [
   'blueBright',
   'magentaBright',
   'cyanBright',
-  'whiteBright'
+  //'whiteBright'
 ]
 
 module.exports = NeatScreen

--- a/views.js
+++ b/views.js
@@ -75,8 +75,8 @@ function renderPrompt (state) {
 
 function renderTitlebar (state, width) {
   return [
-    chalk.bgBlue(util.centerText(chalk.white.bold(`CABAL@${version}`), width)),
-    util.rightAlignText(chalk.white(`cabal://${state.cabal.key.toString('hex')}`), width)
+    chalk.bgBlue(util.centerText(chalk.whiteBright.bold(`CABAL@${version}`), width)),
+    util.rightAlignText(`cabal://${state.cabal.key.toString('hex')}`, width)
   ]
 }
 
@@ -107,14 +107,14 @@ function renderChannels (state, width, height) {
         var fillWidth = width - channelTruncated.length - 3
         var fill = (fillWidth > 0) ? new Array(fillWidth).fill(' ').join('') : ''
         if (state.selectedWindowPane === 'channels') {
-          return '>' + chalk.bgBlue(channelTruncated + fill)
+          return '>' + chalk.whiteBright(chalk.bgBlue(channelTruncated + fill))
         } else {
           return ' ' + chalk.bgBlue(channelTruncated + fill)
         }
       } else {
         if (mentioned) return '@' + chalk.magenta(channelTruncated)
         else if (unread) return '*' + chalk.green(channelTruncated)
-        else return ' ' + chalk.white(channelTruncated)
+        else return ' ' + channelTruncated
       }
     }).slice(0, height)
 }
@@ -146,9 +146,7 @@ function renderNicks (state, width, height) {
     if (user.isAdmin()) name = chalk.green('@') + name
     else if (user.isModerator()) name = chalk.green('%') + name
     if (user.online) {
-      name = chalk.bold(chalk.white(name))
-    } else {
-      name = chalk.gray(name)
+      name = chalk.bold(name)
     }
     return name
   })


### PR DESCRIPTION
With the new peer list the names are hard to read with a light background and also the contrast could be a bit higher for some items with a dark background too.

Before:

![before-light](https://user-images.githubusercontent.com/12631/82741887-cdfab600-9cf2-11ea-8dce-0ab7aa0798bd.png)

![before-dark](https://user-images.githubusercontent.com/12631/82741886-ca672f00-9cf2-11ea-9ede-22d8bd4380ef.png)

After:

![after-light](https://user-images.githubusercontent.com/12631/82741890-dd79ff00-9cf2-11ea-830a-4d4d3f1b0851.png)

![after-dark](https://user-images.githubusercontent.com/12631/82741889-da7f0e80-9cf2-11ea-800d-c775d1d5a197.png)

Plus I tested with a few other combinations of light and dark backgrounds and I think these strike a good balance. Longer term it probably makes sense to have a light mode vs dark mode setting, especially for setting the nick colors but until then (and still for the unconfigured default version) I think it's better to go with settings that work better on a variety of configurations.