### PR TITLE
remove Date.now(), add moderation key in ui

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -17,28 +17,14 @@ function Commander (view, client) {
 Commander.prototype.setActiveCabal = function (cabal) {
   this.cabal = cabal
   if (this._hasListeners[cabal.key]) return
-  var log = this.logger()
   this.cabal.on('info', (msg) => {
     var txt = typeof msg === 'string' ? msg : (msg && msg.text ? msg.text : '')
-    log('* ' + util.sanitizeString(txt))
+    this.view.writeLine('* ' + util.sanitizeString(txt))
   })
   this.cabal.on('error', (err) => {
-    log(chalk.bold(chalk.red('! ' + util.sanitizeString(String(err)))))
+    this.view.writeLine(chalk.bold(chalk.red('! ' + util.sanitizeString(String(err)))))
   })
   this._hasListeners[cabal.key] = true
-}
-
-// for use when writing multiple logs within short intervals
-// to keep timestamp ordering correct. see usage for the `help` command above
-Commander.prototype.logger = function () {
-  var counter = -1000 // set counter 1000 ms in the past to prevent status messages from being purged due to being in the future
-  function ts () {
-    return Date.now() + counter++
-  }
-  var logToView = (msg) => {
-    this.view.writeLine.bind(this.view)(msg, ts())
-  }
-  return logToView
 }
 
 Commander.prototype.process = function (line) {

--- a/neat-screen.js
+++ b/neat-screen.js
@@ -339,7 +339,7 @@ NeatScreen.prototype.initializeCabalClient = function () {
   this.state.messageScrollback = 0
   this.state.userScrollback = 0
   this.client.getCabalKeys().forEach((key) => {
-    welcomeMessage.map((m) => this.client.getDetails(key).addStatusMessage({ text: m }), '!status')
+    welcomeMessage.map((m) => this.client.getDetails(key).addStatusMessage({ text: m }, '!status'))
     this.state.moderationKeys = moderationKeys = this.state.cabal.core.adminKeys.map((k) => { return { key: k, type: 'admin' }}).concat(this.state.cabal.core.modKeys.map((k) => { return { key: k, type: 'mod' }}))
     if (this.state.moderationKeys.length > 0) {
       let moderationMessage = [
@@ -351,7 +351,7 @@ NeatScreen.prototype.initializeCabalClient = function () {
       })
       moderationMessage.push('for more information, type /moderation')
       moderationMessage.forEach((text) => {
-        this.client.getDetails(key).addStatusMessage({ text }) 
+        this.client.getDetails(key).addStatusMessage({ text }, '!status') 
       })
     }
   })

--- a/neat-screen.js
+++ b/neat-screen.js
@@ -338,9 +338,8 @@ NeatScreen.prototype.initializeCabalClient = function () {
   this.state.cabal = details
   this.state.messageScrollback = 0
   this.state.userScrollback = 0
-  var counter = 0
   this.client.getCabalKeys().forEach((key) => {
-    welcomeMessage.map((m) => this.client.getDetails(key).addStatusMessage({ timestamp: Date.now() + counter++, text: m }), '!status')
+    welcomeMessage.map((m) => this.client.getDetails(key).addStatusMessage({ text: m }), '!status')
   })
   this.registerUpdateHandler(details)
   this.loadChannel('!status')
@@ -411,8 +410,8 @@ NeatScreen.prototype.renderApp = function (state) {
 }
 
 // use to write anything else to the screen, e.g. info messages or emotes
-NeatScreen.prototype.writeLine = function (line, timestamp) {
-  this.client.addStatusMessage({ timestamp: timestamp || Date.now(), text: line })
+NeatScreen.prototype.writeLine = function (text) {
+  this.client.addStatusMessage({ text })
   this.bus.emit('render')
 }
 

--- a/neat-screen.js
+++ b/neat-screen.js
@@ -343,12 +343,12 @@ NeatScreen.prototype.initializeCabalClient = function () {
     this.state.moderationKeys = moderationKeys = this.state.cabal.core.adminKeys.map((k) => { return { key: k, type: 'admin' }}).concat(this.state.cabal.core.modKeys.map((k) => { return { key: k, type: 'mod' }}))
     if (this.state.moderationKeys.length > 0) {
       let moderationMessage = [
-      'you joined via a moderation key, meaning you are allowing someone else to help administer moderation on your behalf.', 
-      'if you would like to remove the applied moderation keys, type:'
-      ]
-      this.state.moderationKeys.forEach((k) => {
-        moderationMessage.push(`/un${k.type} ${k.key}`)
-      })
+      'you joined via a moderation key, meaning you are allowing someone else to help administer moderation on your behalf.']
+      // comment out how to remove applied moderators until it actually has a lasting effect across sessions, see https://github.com/cabal-club/cabal-cli/pull/190#discussion_r430021350
+      // moderationMessage.push('if you would like to remove the applied moderation keys, type:')
+      // this.state.moderationKeys.forEach((k) => {
+      //   moderationMessage.push(`/un${k.type} ${k.key}`)
+      // })
       moderationMessage.push('for more information, type /moderation')
       moderationMessage.forEach((text) => {
         this.client.getDetails(key).addStatusMessage({ text }, '!status') 

--- a/neat-screen.js
+++ b/neat-screen.js
@@ -341,6 +341,7 @@ NeatScreen.prototype.initializeCabalClient = function () {
   this.client.getCabalKeys().forEach((key) => {
     welcomeMessage.map((m) => this.client.getDetails(key).addStatusMessage({ text: m }), '!status')
   })
+  this.bus.emit('render')
   this.registerUpdateHandler(details)
   this.loadChannel('!status')
 }

--- a/neat-screen.js
+++ b/neat-screen.js
@@ -340,10 +340,10 @@ NeatScreen.prototype.initializeCabalClient = function () {
   this.state.userScrollback = 0
   this.client.getCabalKeys().forEach((key) => {
     welcomeMessage.map((m) => this.client.getDetails(key).addStatusMessage({ text: m }, '!status'))
-    this.state.moderationKeys = moderationKeys = this.state.cabal.core.adminKeys.map((k) => { return { key: k, type: 'admin' }}).concat(this.state.cabal.core.modKeys.map((k) => { return { key: k, type: 'mod' }}))
+    this.state.moderationKeys = this.state.cabal.core.adminKeys.map((k) => { return { key: k, type: 'admin' } }).concat(this.state.cabal.core.modKeys.map((k) => { return { key: k, type: 'mod' } }))
     if (this.state.moderationKeys.length > 0) {
-      let moderationMessage = [
-      'you joined via a moderation key, meaning you are allowing someone else to help administer moderation on your behalf.']
+      const moderationMessage = [
+        'you joined via a moderation key, meaning you are allowing someone else to help administer moderation on your behalf.']
       // comment out how to remove applied moderators until it actually has a lasting effect across sessions, see https://github.com/cabal-club/cabal-cli/pull/190#discussion_r430021350
       // moderationMessage.push('if you would like to remove the applied moderation keys, type:')
       // this.state.moderationKeys.forEach((k) => {
@@ -351,7 +351,7 @@ NeatScreen.prototype.initializeCabalClient = function () {
       // })
       moderationMessage.push('for more information, type /moderation')
       moderationMessage.forEach((text) => {
-        this.client.getDetails(key).addStatusMessage({ text }, '!status') 
+        this.client.getDetails(key).addStatusMessage({ text }, '!status')
       })
     }
   })
@@ -571,8 +571,8 @@ var colours = [
   'yellowBright',
   'blueBright',
   'magentaBright',
-  'cyanBright',
-  //'whiteBright'
+  'cyanBright'
+  // 'whiteBright'
 ]
 
 module.exports = NeatScreen

--- a/neat-screen.js
+++ b/neat-screen.js
@@ -340,6 +340,20 @@ NeatScreen.prototype.initializeCabalClient = function () {
   this.state.userScrollback = 0
   this.client.getCabalKeys().forEach((key) => {
     welcomeMessage.map((m) => this.client.getDetails(key).addStatusMessage({ text: m }), '!status')
+    this.state.moderationKeys = moderationKeys = this.state.cabal.core.adminKeys.map((k) => { return { key: k, type: 'admin' }}).concat(this.state.cabal.core.modKeys.map((k) => { return { key: k, type: 'mod' }}))
+    if (this.state.moderationKeys.length > 0) {
+      let moderationMessage = [
+      'you joined via a moderation key, meaning you are allowing someone else to help administer moderation on your behalf.', 
+      'if you would like to remove the applied moderation keys, type:'
+      ]
+      this.state.moderationKeys.forEach((k) => {
+        moderationMessage.push(`/un${k.type} ${k.key}`)
+      })
+      moderationMessage.push('for more information, type /moderation')
+      moderationMessage.forEach((text) => {
+        this.client.getDetails(key).addStatusMessage({ text }) 
+      })
+    }
   })
   this.bus.emit('render')
   this.registerUpdateHandler(details)

--- a/util.js
+++ b/util.js
@@ -7,6 +7,21 @@ function log (err, result) {
   if (arguments.length >= 2) { console.log(result) }
 }
 
+// return the most suitable moderation key. 
+// if we don't have one set, default to the current user's key.
+// if we have joined via multiple keys, pick the first admin key. 
+// if we don't have any admin keys, but we do have a mod key, use that instead
+// only return one, due to excessively long keys ':)
+function getModerationKey (state) {
+  let moderationKey = state.cabal.user ? `?admin=${state.cabal.user.key}` : ''
+  if (state.moderationKeys.length > 0) {
+      // if admin key is set, it will be at the top. otherwise we'll set a mod key
+      const key = state.moderationKeys[0]
+      moderationKey = `?${key.type}=${key.key}`
+  }
+  return moderationKey
+}
+
 function sanitizeString (str) {
   // emojis break the cli: replace them with shortcodes
   str = emojiConverter.replaceUnicode(str)
@@ -136,4 +151,4 @@ function cmpUser (a, b) {
   return a.key < b.key ? -1 : 1
 }
 
-module.exports = { cmpUser, log, wrapAnsi, strlenAnsi, centerText, rightAlignText, wrapStatusMsg, sanitizeString, unambiguous }
+module.exports = { cmpUser, log, wrapAnsi, strlenAnsi, centerText, rightAlignText, wrapStatusMsg, sanitizeString, unambiguous, getModerationKey }

--- a/util.js
+++ b/util.js
@@ -7,17 +7,17 @@ function log (err, result) {
   if (arguments.length >= 2) { console.log(result) }
 }
 
-// return the most suitable moderation key. 
+// return the most suitable moderation key.
 // if we don't have one set, default to the current user's key.
-// if we have joined via multiple keys, pick the first admin key. 
+// if we have joined via multiple keys, pick the first admin key.
 // if we don't have any admin keys, but we do have a mod key, use that instead
 // only return one, due to excessively long keys ':)
 function getModerationKey (state) {
   let moderationKey = state.cabal.user ? `?admin=${state.cabal.user.key}` : ''
   if (state.moderationKeys.length > 0) {
-      // if admin key is set, it will be at the top. otherwise we'll set a mod key
-      const key = state.moderationKeys[0]
-      moderationKey = `?${key.type}=${key.key}`
+    // if admin key is set, it will be at the top. otherwise we'll set a mod key
+    const key = state.moderationKeys[0]
+    moderationKey = `?${key.type}=${key.key}`
   }
   return moderationKey
 }

--- a/views.js
+++ b/views.js
@@ -75,7 +75,7 @@ function renderPrompt (state) {
 }
 
 function renderTitlebar (state, width) {
-  const moderationKey = util.getModerationKey(state)
+  const moderationKey = chalk.cyan(util.getModerationKey(state))
   return [
     chalk.bgBlue(util.centerText(chalk.whiteBright.bold(`CABAL@${version}`), width)),
     util.rightAlignText(`cabal://${state.cabal.key.toString('hex')}${moderationKey}`, width)

--- a/views.js
+++ b/views.js
@@ -63,7 +63,7 @@ function big (state) {
 
 function linkSize (state) {
   const moderationKey = util.getModerationKey(state)
-  if (state.cabal.key) return `cabal://${state.cabal.key.toString('hex')}`.length + adminKey.length
+  if (state.cabal.key) return `cabal://${state.cabal.key.toString('hex')}`.length + moderationKey.length
   else return 'cabal://...'
 }
 

--- a/views.js
+++ b/views.js
@@ -62,7 +62,8 @@ function big (state) {
 }
 
 function linkSize (state) {
-  if (state.cabal.key) return `cabal://${state.cabal.key.toString('hex')}`.length
+  const moderationKey = util.getModerationKey(state)
+  if (state.cabal.key) return `cabal://${state.cabal.key.toString('hex')}`.length + adminKey.length
   else return 'cabal://...'
 }
 
@@ -74,9 +75,10 @@ function renderPrompt (state) {
 }
 
 function renderTitlebar (state, width) {
+  const moderationKey = util.getModerationKey(state)
   return [
     chalk.bgBlue(util.centerText(chalk.white.bold(`CABAL@${version}`), width)),
-    util.rightAlignText(chalk.white(`cabal://${state.cabal.key.toString('hex')}`), width)
+    util.rightAlignText(chalk.white(`cabal://${state.cabal.key.toString('hex')}${moderationKey}`), width)
   ]
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3862362/82886642-1c07f780-9f47-11ea-8e5a-7d02ce74d1f3.png)

* fixes ordering of command output from cli by relying on cabal-client's use of monotonic timestamps
* also displays active moderation key in the ui, see comment in [util.js](https://github.com/cabal-club/cabal-cli/pull/190/files#diff-63f3aa32c5cc5d42a250b081693e9dc2R10-R14)
* highlight admin/mod portion of cabal key (make it easier for people to copy just cabal key, if they wish)


relies on https://github.com/cabal-club/cabal-client/pull/50