### PR TITLE
Sort hidden users to bottom of user pane, prefix their names with minus sign

### DIFF
--- a/neat-screen.js
+++ b/neat-screen.js
@@ -506,9 +506,9 @@ NeatScreen.prototype.formatMessage = function (msg) {
 
     var timestamp = `${chalk.dim(formatTime(msg.value.timestamp, this.config.messageTimeformat))}`
     let authorText
-    if (msg.value.type === 'status') {
+    if (msg.value.type === 'status' || msg.value.type === 'chat/moderation') {
       highlight = false // never highlight from status
-      authorText = `${chalk.dim('-')}${highlight ? chalk.whiteBright(author) : chalk.cyan('status')}${chalk.dim('-')}`
+      authorText = `${chalk.dim('-')}${chalk.cyan('status')}${chalk.dim('-')}`
     } else {
       /* a user wrote a message, not the !status virtual message */
 
@@ -531,6 +531,22 @@ NeatScreen.prototype.formatMessage = function (msg) {
 
     if (msg.value.type === 'chat/topic') {
       content = `${chalk.dim(`* sets the topic to ${chalk.cyan(msgtxt)}`)}`
+    } else if (msg.value.type === 'chat/moderation') {
+      const { role, type, issuerid, receiverid } = msg.value.content
+      const issuer = this.client.getUsers()[issuerid]
+      const receiver = this.client.getUsers()[receiverid]
+      let text, action
+      const reason = msg.value.content.reason ? `(${chalk.cyan('reason:')} ${msg.value.content.reason})` : ''
+      const issuerName = issuer && issuer.name ? issuer.name : issuerid.slice(0, 8)
+      const receiverName = receiver && receiver.name ? receiver.name : eceiverid.slice(0, 8)
+      if (['admin', 'mod'].includes(role)) { action = (type === 'add' ? 'added' : 'removed') }
+      if (role === 'hide') { action = (type === 'add' ? 'hid' : 'unhid') }
+      if (role === 'hide')  {
+        text = `${issuerName} ${chalk.cyan(action)} ${receiverName} ${reason}`
+      } else {
+        text = `${issuerName} ${chalk.cyan(action)} ${receiverName} as ${chalk.cyan(role)} ${reason}`
+      }
+      content = `${chalk.magenta('moderation')}: ${text}`
     }
 
     return {

--- a/neat-screen.js
+++ b/neat-screen.js
@@ -538,7 +538,7 @@ NeatScreen.prototype.formatMessage = function (msg) {
       let text, action
       const reason = msg.value.content.reason ? `(${chalk.cyan('reason:')} ${msg.value.content.reason})` : ''
       const issuerName = issuer && issuer.name ? issuer.name : issuerid.slice(0, 8)
-      const receiverName = receiver && receiver.name ? receiver.name : eceiverid.slice(0, 8)
+      const receiverName = receiver && receiver.name ? receiver.name : receiverid.slice(0, 8)
       if (['admin', 'mod'].includes(role)) { action = (type === 'add' ? 'added' : 'removed') }
       if (role === 'hide') { action = (type === 'add' ? 'hid' : 'unhid') }
       if (role === 'hide')  {

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,9 +101,9 @@
       }
     },
     "@hyperswarm/discovery": {
-      "version": "1.11.4",
-      "resolved": "https://registry.npmjs.org/@hyperswarm/discovery/-/discovery-1.11.4.tgz",
-      "integrity": "sha512-IZ902SwvoV7CAnsNvCymV8CdFUOupNB6Shk207sUQfK7b3qHc/hP90bu0xsVDrao+YCQPC3J6Zdpb+Q047MBTg==",
+      "version": "1.11.5",
+      "resolved": "https://registry.npmjs.org/@hyperswarm/discovery/-/discovery-1.11.5.tgz",
+      "integrity": "sha512-C5Hbq31lkfrjFytuujSxzvied3PzDU98xeKs34oW/D7NIexGM13dqKC8mMDxkxkqXDMzx/vKrwvD/Jfd+q79uQ==",
       "requires": {
         "@hyperswarm/dht": "^3.2.0",
         "multicast-dns": "^7.2.0",
@@ -523,11 +523,11 @@
       "dev": true
     },
     "cabal-client": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cabal-client/-/cabal-client-5.1.0.tgz",
-      "integrity": "sha512-146UxQM3MYNk66FCAeHtx5GAHvwVUTE6jZj5e6nGgDEb69h8zvjGkQ0qoM3BFVsaZccjGycYFn4BJIDMlMegqw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cabal-client/-/cabal-client-6.1.0.tgz",
+      "integrity": "sha512-y/8CJBR4+f8MIdwXCfKevYzkV7Jdnb19WDixFValn6U180zKIA4dWkoWaD0B1Kr9PNy2bKLT1/ixG2Tsn76e/g==",
       "requires": {
-        "cabal-core": "^12.0.0",
+        "cabal-core": "^13.0.0",
         "collect-stream": "^1.2.1",
         "dat-dns": "^4.0.1",
         "debug": "^4.1.1",
@@ -554,9 +554,9 @@
       }
     },
     "cabal-core": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/cabal-core/-/cabal-core-12.0.0.tgz",
-      "integrity": "sha512-FqE5wUtMK0wYNcYFsZ19vl5Gcboh83EMMmVWD/TWdB7ZiapwCF7D+8aU/fzTINFQUOL/Tre6MCddjwRYRT2e3A==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/cabal-core/-/cabal-core-13.0.0.tgz",
+      "integrity": "sha512-R+aeOtpcuseDRYuqBXUJO2MCwLTupxax3EPXR1XcaqKSqlTxgQRtt7NVT93+qJH8HYzDH8H3O/poDvEaSZLT3Q==",
       "requires": {
         "charwise": "^3.0.1",
         "collect-stream": "^1.2.1",
@@ -2131,9 +2131,9 @@
       "dev": true
     },
     "immediate": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
-      "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
+      "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q=="
     },
     "import-fresh": {
       "version": "3.2.1",
@@ -2908,6 +2908,11 @@
             "level-supports": "~1.0.0",
             "xtend": "~4.0.0"
           }
+        },
+        "immediate": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
+          "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
         }
       }
     },
@@ -3140,9 +3145,9 @@
       }
     },
     "multifeed-index": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/multifeed-index/-/multifeed-index-3.4.1.tgz",
-      "integrity": "sha512-Z0hWW207BN/TSQ1iW4VSJoO2vHoEYqbUDYdh/VZul1Pj15HmufksHLqAOND5BqhDTGBa+CgWxbgXh2Ofe57emw==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/multifeed-index/-/multifeed-index-3.4.2.tgz",
+      "integrity": "sha512-pkslwCz3Ih5CwLqKLqY9eG+xNfigSO3mxFtt7sEFOMRdD64H/3pKzU6n9CB71/4uSLaEtounfJBbbzPbnJsKAg==",
       "requires": {
         "clone": "^2.1.2",
         "inherits": "^2.0.3"
@@ -3942,9 +3947,9 @@
       "dev": true
     },
     "query-string": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.12.1.tgz",
-      "integrity": "sha512-OHj+zzfRMyj3rmo/6G8a5Ifvw3AleL/EbcHMD27YA31Q+cO5lfmQxECkImuNVjcskLcvBRVHNAB3w6udMs1eAA==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.0.tgz",
+      "integrity": "sha512-KJe8p8EUcixhPCp4cJoTYVfmgKHjnAB/Pq3fiqlmyNHvpHnOL5U4YE7iI2PYivGHp4HFocWz300906BAQX0H7g==",
       "requires": {
         "decode-uri-component": "^0.2.0",
         "split-on-first": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "ansi-escapes": "^4.3.1",
-    "cabal-client": "^5.1.0",
+    "cabal-client": "^6.1.0",
     "chalk": "^4.0.0",
     "js-yaml": "^3.13.1",
     "minimist": "^1.2.5",

--- a/util.js
+++ b/util.js
@@ -139,6 +139,8 @@ function wrapStatusMsg (m) {
 }
 
 function cmpUser (a, b) {
+  if (!a.isHidden() && b.isHidden()) return -1
+  if (!b.isHidden() && a.isHidden()) return 1
   if (a.online && !b.online) return -1
   if (b.online && !a.online) return 1
   if (a.isAdmin() && !b.isAdmin()) return -1

--- a/views.js
+++ b/views.js
@@ -147,6 +147,7 @@ function renderNicks (state, width, height) {
     if (user.online) onlines[name] = name in onlines ? onlines[name] + 1 : 1
     if (user.isAdmin()) name = chalk.green('@') + name
     else if (user.isModerator()) name = chalk.green('%') + name
+    else if (user.isHidden()) name = chalk.green('-') + name
     if (user.online) {
       name = chalk.bold(name)
     }


### PR DESCRIPTION
this pr sorts hidden users to the bottom of the user pane (probably dont want someone you've hidden to be in yr face). 

their names are also prefixed with a minus sign; eases the amount of mental accounting you need to do to know who is banned & not. see image below for demo

![Screen Shot 2020-06-05 at 11 02 57](https://user-images.githubusercontent.com/3862362/83858072-32b70700-a71c-11ea-8b7e-bc7d504ff72c.png)

this PR also greatly improves the styling of applied moderation messages, which are virtual messages with type `chat/moderation`. see image below

![image](https://user-images.githubusercontent.com/3862362/84240796-d0387f00-aafe-11ea-838f-7e3b78288067.png)

