### PR TITLE
add --port arg + preferredPort to config for custom port

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ This will run cabal without a UI. You can use this to seed a cabal (e.g. on a VP
 cabal <key> --seed
 ```
 
+#### Custom port
+If you have a tightly configured firewall and need to port-forward a port, the default port Cabal uses is port `13331`.
+You can change this with the `--port` flag, or setting `preferredPort` in your .cabal.yml config file.
+
+```
+cabal <key> --seed --port 7331
+```
+
 ## Commands
 ```py
 /add, /cabal

--- a/cli.js
+++ b/cli.js
@@ -60,6 +60,7 @@ var usage = `Usage
 
   Options:
     --seed    Start a headless seed for the specified cabal key
+    --port    Listen for cabal traffic on the passed in port (default: 13331)
 
     --new     Start a new cabal
     --nick    Your nickname
@@ -112,6 +113,7 @@ if (!fs.existsSync(rootconfig)) {
   saveConfig(rootconfig, {
     cabals: [],
     aliases: {},
+    preferredPort: 0,
     cache: {},
     frontend: {
       messageTimeformat: defaultMessageTimeformat,
@@ -130,6 +132,7 @@ try {
     }
     if (!config.cabals) { config.cabals = [] }
     if (!config.aliases) { config.aliases = {} }
+    if (!config.preferredPort) { config.preferredPort = 0 }
     if (!config.cache) { config.cache = {} }
     if (!config.frontend) { config.frontend = {} }
     if (!config.frontend.messageTimeformat) {
@@ -149,7 +152,8 @@ const client = new Client({
   maxFeeds: maxFeeds,
   config: {
     dbdir: archivesdir,
-    temp: args.temp
+    temp: args.temp,
+    preferredPort: args.port || config.preferredPort
   },
   commands: {
     // todo: custom commands
@@ -366,6 +370,16 @@ if (args.alias && args.key) {
   saveKeyAsAlias(args.key, args.alias)
   process.exit(0)
 }
+
+if (args.port) {
+  let port = parseInt(args.port)
+  if (isNaN(port) || port < 0 || port > 65535) {
+    logError(`${args.port} is not a valid port number`)
+    process.exit(1)
+  }
+  args.port = port
+}
+
 
 if (args.key) {
   // If a key is provided, place it at the top of the keys provided from the config

--- a/package-lock.json
+++ b/package-lock.json
@@ -522,9 +522,9 @@
       "dev": true
     },
     "cabal-client": {
-      "version": "6.2.6",
-      "resolved": "https://registry.npmjs.org/cabal-client/-/cabal-client-6.2.6.tgz",
-      "integrity": "sha512-IKOyTBdVOenJGkMNCNteA5GsDIswYBBwDWiPF+qt0NADuaLGAhmVoSPG/aSfoubFnpeg5CyDMdoNEiEOoq2Qwg==",
+      "version": "6.2.7",
+      "resolved": "https://registry.npmjs.org/cabal-client/-/cabal-client-6.2.7.tgz",
+      "integrity": "sha512-pTvreWollaUDQQcDxvRLX9WCXX0Fw0O/fLskdD8uSi3ffC9Na9UHhj9YmQ+h43/qgYCFV/CIBINQ7PqaKafwZw==",
       "requires": {
         "cabal-core": "^13.1.0",
         "collect-stream": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "ansi-escapes": "^4.3.1",
-    "cabal-client": "^6.2.5",
+    "cabal-client": "^6.2.6",
     "chalk": "^4.0.0",
     "js-yaml": "^3.13.1",
     "minimist": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "ansi-escapes": "^4.3.1",
-    "cabal-client": "^6.2.6",
+    "cabal-client": "^6.2.7",
     "chalk": "^4.0.0",
     "js-yaml": "^3.13.1",
     "minimist": "^1.2.5",


### PR DESCRIPTION
this pr adds the ability for the cli to set a custom port (the default being port `13331`) to listen for cabal traffic on, which as been requested previously https://github.com/cabal-club/cabal-core/issues/98

to permanently change the port for your cli client, you can also set it as a config option under `preferredPort` in one of your .yml config files (wherever they are located, lol)

oh yeah this pr relies on https://github.com/cabal-club/cabal-client/pull/67