### PR TITLE
Client updates [archiving support]

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -159,7 +159,7 @@ const client = new Client({
     // todo: custom commands
     panes: {
       help: () => 'set pane to navigate up and down in. panes: channels, cabals',
-      category: ["misc"],
+      category: ['misc'],
       call: (cabal, res, arg) => {
         if (arg === '' || !['channels', 'cabals'].includes(arg)) return
         fe.setPane(arg)
@@ -167,21 +167,21 @@ const client = new Client({
     },
     quit: {
       help: () => 'exit the cabal process',
-      category: ["basics"],
+      category: ['basics'],
       call: (cabal, res, arg) => {
         process.exit(0)
       }
     },
     exit: {
       help: () => 'exit the cabal process',
-      category: ["basics"],
+      category: ['basics'],
       call: (cabal, res, arg) => {
         process.exit(0)
       }
     },
     help: {
       help: () => 'display this help message',
-      category: ["basics"],
+      category: ['basics'],
       call: (cabal, res, arg) => {
         const hotkeysExplanation = `
 ctrl-l  
@@ -221,12 +221,12 @@ ctrl-{n,p}
 alt-l  
   toggle id suffixes on/off  
 `
-        let categories = new Set(["hotkeys"])
+        const categories = new Set(['hotkeys'])
 
         function printCategories () {
           for (const cat of Array.from(categories).sort((a, b) => a.localeCompare(b))) {
             fe.writeLine(`/help ${chalk.cyan(cat)}`)
-          } 
+          }
         }
         var foundAliases = {}
         const commands = {}
@@ -239,16 +239,14 @@ alt-l
           })
         }
         if (!arg) {
-          fe.writeLine("the help command is split into sections:")
+          fe.writeLine('the help command is split into sections:')
           printCategories()
-          return
         } else if (arg && !categories.has(arg)) {
           fe.writeLine(`${arg} is not a help section, try:`)
           printCategories()
-          return
         } else {
           fe.writeLine(`help: ${chalk.cyan(arg)}`)
-          if (arg === "hotkeys") {
+          if (arg === 'hotkeys') {
             fe.writeLine(hotkeysExplanation)
             return
           }
@@ -308,7 +306,7 @@ if (args.clear) {
 if (args.forget) {
   let success = false
   /* eslint no-inner-declarations: "off" */
-  function forgetCabal(k) {
+  function forgetCabal (k) {
     const index = config.cabals.indexOf(k)
     if (index >= 0) {
       config.cabals.splice(index, 1)
@@ -372,14 +370,13 @@ if (args.alias && args.key) {
 }
 
 if (args.port) {
-  let port = parseInt(args.port)
+  const port = parseInt(args.port)
   if (isNaN(port) || port < 0 || port > 65535) {
     logError(`${args.port} is not a valid port number`)
     process.exit(1)
   }
   args.port = port
 }
-
 
 if (args.key) {
   // If a key is provided, place it at the top of the keys provided from the config
@@ -441,7 +438,7 @@ if (args.qr) {
   process.exit(1)
 }
 
-function start(keys, frontendConfig) {
+function start (keys, frontendConfig) {
   if (args.key && args.message) {
     publishSingleMessage({
       key: args.key,
@@ -491,13 +488,13 @@ function start(keys, frontendConfig) {
   })
 }
 
-function trackAndPrintEvents(cabal) {
+function trackAndPrintEvents (cabal) {
   cabal.ready(() => {
     // Listen for feeds
     cabal.kcore._logs.feeds().forEach(listen)
     cabal.kcore._logs.on('feed', listen)
 
-    function listen(feed) {
+    function listen (feed) {
       feed.on('download', idx => {
         process.stdout.write('.')
       })
@@ -516,18 +513,18 @@ function trackAndPrintEvents(cabal) {
   })
 }
 
-function getKey(str) {
+function getKey (str) {
   // return key if what was passed in was a saved alias
   if (str in config.aliases) { return config.aliases[str] }
   // else assume it's a cabal key
   return str
 }
 
-function logError(msg) {
+function logError (msg) {
   console.error(`${chalk.red('cabal:')} ${msg}`)
 }
 
-function findConfigPath() {
+function findConfigPath () {
   var currentDirConfigFilename = '.cabal.yml'
   if (args.config && fs.statSync(args.config).isDirectory()) {
     return path.join(args.config, `v${Client.getDatabaseVersion()}`, 'config.yml')
@@ -539,7 +536,7 @@ function findConfigPath() {
   return rootconfig
 }
 
-function saveConfig(path, config) {
+function saveConfig (path, config) {
   // make sure config is well-formatted (contains all config options)
   if (!config.cabals) { config.cabals = [] }
   config.cabals = Array.from(new Set(config.cabals)) // dedupe array entries
@@ -550,13 +547,13 @@ function saveConfig(path, config) {
   fs.writeFileSync(path, data, 'utf8')
 }
 
-function saveKeyAsAlias(key, alias) {
+function saveKeyAsAlias (key, alias) {
   config.aliases[alias] = key
   saveConfig(configFilePath, config)
   console.log(`${chalk.magentaBright('cabal:')} saved ${chalk.greenBright(key)} as ${chalk.blueBright(alias)}`)
 }
 
-function publishSingleMessage({ key, channel, message, messageType, timeout }) {
+function publishSingleMessage ({ key, channel, message, messageType, timeout }) {
   console.log(`Publishing message to channel - ${channel || 'default'}: ${message}`)
   client.addCabal(key).then(cabal => cabal.publishMessage({
     type: messageType || 'chat/text',
@@ -569,7 +566,7 @@ function publishSingleMessage({ key, channel, message, messageType, timeout }) {
   setTimeout(function () { process.exit(0) }, timeout || 5000)
 }
 
-function getClientVersion() {
+function getClientVersion () {
   if (packageJSONVersion) {
     return packageJSONVersion
   }

--- a/commands.js
+++ b/commands.js
@@ -23,17 +23,17 @@ Commander.prototype.setActiveCabal = function (cabal) {
     const meta = msg.meta
     if (meta.command) {
       switch (meta.command) {
-          case "channels":
-            if (meta.seq === 0) break // don't rewrite the payload of the first `/channels` message
-            var {joined, channel, userCount, topic} = msg
-            var userPart = `${userCount} ${userCount === 1 ? 'person' : 'people'}` 
-            userPart = userCount > 0 ? ": " + chalk.cyan(userPart) : ''
-            const maxTopicLength = views.getChatWidth() -  `00:00:00 -status-   ${channel}: 999 people `.length - 2 /* misc unknown padding that just makes it work v0v */
-            var shortTopic = topic && topic.length > maxTopicLength ? topic.slice(0, maxTopicLength-2) + '..' : topic || ''
-            shortTopic = util.sanitizeString(shortTopic)
-            channel = util.sanitizeString(channel)
-            txt = `${joined ? '*' : ' '} ${channel}${userPart} ${shortTopic}`
-            break
+        case 'channels':
+          if (meta.seq === 0) break // don't rewrite the payload of the first `/channels` message
+          var { joined, channel, userCount, topic } = msg
+          var userPart = `${userCount} ${userCount === 1 ? 'person' : 'people'}`
+          userPart = userCount > 0 ? ': ' + chalk.cyan(userPart) : ''
+          var maxTopicLength = views.getChatWidth() - `00:00:00 -status-   ${channel}: 999 people `.length - 2 /* misc unknown padding that just makes it work v0v */
+          var shortTopic = topic && topic.length > maxTopicLength ? topic.slice(0, maxTopicLength - 2) + '..' : topic || ''
+          shortTopic = util.sanitizeString(shortTopic)
+          channel = util.sanitizeString(channel)
+          txt = `${joined ? '*' : ' '} ${channel}${userPart} ${shortTopic}`
+          break
       }
     }
     this.view.writeLine(txt)

--- a/commands.js
+++ b/commands.js
@@ -10,7 +10,7 @@ function Commander (view, client) {
   this.view = view
   this.pattern = (/^\/(\w*)\s*(.*)/)
   this.history = []
-  this.historyIndex = -1 // negative: new msg. >=0: index from the last item
+  this.historyIndex = -1 // negative: new msg, >=0: index from the last item
 }
 
 Commander.prototype.setActiveCabal = function (cabal) {
@@ -19,13 +19,15 @@ Commander.prototype.setActiveCabal = function (cabal) {
   this.cabal.on('info', (msg) => {
     var txt = typeof msg === 'string' ? msg : (msg && msg.text ? msg.text : '')
     txt = util.sanitizeString(txt)
-    if (msg.command) {
-      switch (msg.command) {
+    const meta = msg.meta
+    if (meta.command) {
+      switch (meta.command) {
           case "channels":
+            if (meta.seq === 0) break // don't rewrite the payload of the first `/channels` message
             var {joined, channel, userCount, topic} = msg
             var userPart = `${userCount} ${userCount === 1 ? 'person' : 'people'}` 
             userPart = userCount > 0 ? ": " + chalk.cyan(userPart) : ''
-            var shortTopic = topic.length > 40 ? topic.slice(0, 40) + '..' : topic || ''
+            var shortTopic = topic && topic.length > 40 ? topic.slice(0, 40) + '..' : topic || ''
             shortTopic = util.sanitizeString(shortTopic)
             channel = util.sanitizeString(channel)
             txt = `${joined ? '*' : ' '} ${channel}${userPart} ${shortTopic}`

--- a/commands.js
+++ b/commands.js
@@ -1,5 +1,6 @@
 var util = require('./util')
 var chalk = require('chalk')
+var views = require('./views')
 
 function Commander (view, client) {
   if (!(this instanceof Commander)) return new Commander(view, client)
@@ -27,7 +28,8 @@ Commander.prototype.setActiveCabal = function (cabal) {
             var {joined, channel, userCount, topic} = msg
             var userPart = `${userCount} ${userCount === 1 ? 'person' : 'people'}` 
             userPart = userCount > 0 ? ": " + chalk.cyan(userPart) : ''
-            var shortTopic = topic && topic.length > 40 ? topic.slice(0, 40) + '..' : topic || ''
+            const maxTopicLength = views.getChatWidth() -  `00:00:00 -status-   ${channel}: 999 people `.length - 2 /* misc unknown padding that just makes it work v0v */
+            var shortTopic = topic && topic.length > maxTopicLength ? topic.slice(0, maxTopicLength-2) + '..' : topic || ''
             shortTopic = util.sanitizeString(shortTopic)
             channel = util.sanitizeString(channel)
             txt = `${joined ? '*' : ' '} ${channel}${userPart} ${shortTopic}`

--- a/neat-screen.js
+++ b/neat-screen.js
@@ -397,6 +397,24 @@ NeatScreen.prototype.registerUpdateHandler = function (cabal) {
   }
   // register an event handler for all updates from the cabal
   cabal.on('update', this._updateHandler[cabal.key])
+  cabal.on("channel-archive", ({ channel, reason, key, isLocal }) => {
+    const issuer = this.client.getUsers()[key]
+    if (!issuer || isLocal ) { return }
+    reason = reason ? `(${chalk.cyan('reason:')} ${reason})` : ''
+    const issuerName = issuer && issuer.name ? issuer.name : key.slice(0, 8)
+    const text = `${issuerName} ${chalk.magenta('archived')} channel ${chalk.cyan(channel)}`
+    this.client.addStatusMessage({ text })
+    this.bus.emit("render")
+  })
+  cabal.on("channel-unarchive", (envelope) => {
+    const issuer = this.client.getUsers()[key]
+    if (!issuer || isLocal ) { return }
+    reason = reason ? `(${chalk.cyan('reason:')} ${reason})` : ''
+    const issuerName = issuer && issuer.name ? issuer.name : key.slice(0, 8)
+    const text = `${issuerName} ${chalk.magenta('unarchived')} channel ${chalk.cyan(channel)}`
+    this.client.addStatusMessage({ text })
+    this.bus.emit("render")
+  })
 }
 
 NeatScreen.prototype._pagesize = function () {

--- a/neat-screen.js
+++ b/neat-screen.js
@@ -415,7 +415,7 @@ NeatScreen.prototype.processMessages = function (opts, cb) {
     this.state.messages = []
     msgs.forEach((msg, i) => {
       const user = this.client.getUsers()[msg.key]
-      if (user && user.isHidden()) return
+      if (user && user.isHidden(opts.channel)) return
       this.state.messages.push(this.formatMessage(msg))
     })
     this.bus.emit('render')

--- a/neat-screen.js
+++ b/neat-screen.js
@@ -397,24 +397,19 @@ NeatScreen.prototype.registerUpdateHandler = function (cabal) {
   }
   // register an event handler for all updates from the cabal
   cabal.on('update', this._updateHandler[cabal.key])
-  cabal.on("channel-archive", ({ channel, reason, key, isLocal }) => {
+  // create & register event handlers for channel archiving events
+  const processChannelArchiving = (type, { channel, reason, key, isLocal }) => {
     const issuer = this.client.getUsers()[key]
     if (!issuer || isLocal ) { return }
     reason = reason ? `(${chalk.cyan('reason:')} ${reason})` : ''
     const issuerName = issuer && issuer.name ? issuer.name : key.slice(0, 8)
-    const text = `${issuerName} ${chalk.magenta('archived')} channel ${chalk.cyan(channel)}`
+    const action = type === "archive" ? "archived" : "unarchived"
+    const text = `${issuerName} ${chalk.magenta(action)} channel ${chalk.cyan(channel)} ${reason}`
     this.client.addStatusMessage({ text })
     this.bus.emit("render")
-  })
-  cabal.on("channel-unarchive", (envelope) => {
-    const issuer = this.client.getUsers()[key]
-    if (!issuer || isLocal ) { return }
-    reason = reason ? `(${chalk.cyan('reason:')} ${reason})` : ''
-    const issuerName = issuer && issuer.name ? issuer.name : key.slice(0, 8)
-    const text = `${issuerName} ${chalk.magenta('unarchived')} channel ${chalk.cyan(channel)}`
-    this.client.addStatusMessage({ text })
-    this.bus.emit("render")
-  })
+  }
+  cabal.on("channel-archive", (envelope) => { processChannelArchiving("archive", envelope) })
+  cabal.on("channel-unarchive", (envelope) => { processChannelArchiving("unarchive", envelope) })
 }
 
 NeatScreen.prototype._pagesize = function () {

--- a/neat-screen.js
+++ b/neat-screen.js
@@ -233,7 +233,7 @@ function NeatScreen (props) {
 
   // redraw the screen
   this.neat.input.on('ctrl-l', () => {
-      this.neat.clear()
+    this.neat.clear()
   })
 
   // cycle to next unread channel
@@ -400,16 +400,16 @@ NeatScreen.prototype.registerUpdateHandler = function (cabal) {
   // create & register event handlers for channel archiving events
   const processChannelArchiving = (type, { channel, reason, key, isLocal }) => {
     const issuer = this.client.getUsers()[key]
-    if (!issuer || isLocal ) { return }
+    if (!issuer || isLocal) { return }
     reason = reason ? `(${chalk.cyan('reason:')} ${reason})` : ''
     const issuerName = issuer && issuer.name ? issuer.name : key.slice(0, 8)
-    const action = type === "archive" ? "archived" : "unarchived"
+    const action = type === 'archive' ? 'archived' : 'unarchived'
     const text = `${issuerName} ${chalk.magenta(action)} channel ${chalk.cyan(channel)} ${reason}`
     this.client.addStatusMessage({ text })
-    this.bus.emit("render")
+    this.bus.emit('render')
   }
-  cabal.on("channel-archive", (envelope) => { processChannelArchiving("archive", envelope) })
-  cabal.on("channel-unarchive", (envelope) => { processChannelArchiving("unarchive", envelope) })
+  cabal.on('channel-archive', (envelope) => { processChannelArchiving('archive', envelope) })
+  cabal.on('channel-unarchive', (envelope) => { processChannelArchiving('unarchive', envelope) })
 }
 
 NeatScreen.prototype._pagesize = function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,9 +89,9 @@
       },
       "dependencies": {
         "sodium-native": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-3.2.0.tgz",
-          "integrity": "sha512-8aq/vQSegLwsRch8Sb/Bpf9aAqlNe5dp0+NVhb9UjHv42zDZ0D5zX3wBRUbXK9Ejum9uZE6DUgT4vVLlUFRBWg==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-3.2.1.tgz",
+          "integrity": "sha512-EgDZ/Z7PxL2kCasKk7wnRkV8W9kvwuIlHuHXAxkQm3FF0MgVsjyLBXGjSRGhjE6u7rhSpk3KaMfFM23bfMysIQ==",
           "requires": {
             "ini": "^1.3.5",
             "node-gyp-build": "^4.2.0"
@@ -118,9 +118,9 @@
       },
       "dependencies": {
         "sodium-native": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-3.2.0.tgz",
-          "integrity": "sha512-8aq/vQSegLwsRch8Sb/Bpf9aAqlNe5dp0+NVhb9UjHv42zDZ0D5zX3wBRUbXK9Ejum9uZE6DUgT4vVLlUFRBWg==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-3.2.1.tgz",
+          "integrity": "sha512-EgDZ/Z7PxL2kCasKk7wnRkV8W9kvwuIlHuHXAxkQm3FF0MgVsjyLBXGjSRGhjE6u7rhSpk3KaMfFM23bfMysIQ==",
           "requires": {
             "ini": "^1.3.5",
             "node-gyp-build": "^4.2.0"
@@ -408,9 +408,9 @@
       },
       "dependencies": {
         "sodium-native": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-3.2.0.tgz",
-          "integrity": "sha512-8aq/vQSegLwsRch8Sb/Bpf9aAqlNe5dp0+NVhb9UjHv42zDZ0D5zX3wBRUbXK9Ejum9uZE6DUgT4vVLlUFRBWg==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-3.2.1.tgz",
+          "integrity": "sha512-EgDZ/Z7PxL2kCasKk7wnRkV8W9kvwuIlHuHXAxkQm3FF0MgVsjyLBXGjSRGhjE6u7rhSpk3KaMfFM23bfMysIQ==",
           "requires": {
             "ini": "^1.3.5",
             "node-gyp-build": "^4.2.0"
@@ -522,11 +522,11 @@
       "dev": true
     },
     "cabal-client": {
-      "version": "6.2.7",
-      "resolved": "https://registry.npmjs.org/cabal-client/-/cabal-client-6.2.7.tgz",
-      "integrity": "sha512-pTvreWollaUDQQcDxvRLX9WCXX0Fw0O/fLskdD8uSi3ffC9Na9UHhj9YmQ+h43/qgYCFV/CIBINQ7PqaKafwZw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/cabal-client/-/cabal-client-6.3.0.tgz",
+      "integrity": "sha512-xOVa5YMjLftOHOlbGiQK/N/PIvw2E0bXsBEOogJGITIp7SNmUfhVSFIpQpOiiVXEnq02Fl3x6lpQrEgDO2haug==",
       "requires": {
-        "cabal-core": "^13.1.0",
+        "cabal-core": "^13.2.0",
         "collect-stream": "^1.2.1",
         "dat-dns": "^4.1.2",
         "debug": "^4.1.1",
@@ -544,9 +544,9 @@
       }
     },
     "cabal-core": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/cabal-core/-/cabal-core-13.1.0.tgz",
-      "integrity": "sha512-4HRGvzDMtXLxb/VRv/kQrn7Ph/bc2bsP8X9oXfY6DrTZV7ynu0WA9xmhrIcXCiPuVb1HLFC3WOCt6B3W04vlNw==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/cabal-core/-/cabal-core-13.2.0.tgz",
+      "integrity": "sha512-l6lCDO/nisragg5gkjGJ/vzPL1Nu+u+SUlrg2PN5vaeGntbnVsADaQo88L5p63RuU1nW53dWdICyyeE5h/kuJg==",
       "requires": {
         "charwise": "^3.0.1",
         "collect-stream": "^1.2.1",
@@ -1035,9 +1035,9 @@
       },
       "dependencies": {
         "sodium-native": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-3.2.0.tgz",
-          "integrity": "sha512-8aq/vQSegLwsRch8Sb/Bpf9aAqlNe5dp0+NVhb9UjHv42zDZ0D5zX3wBRUbXK9Ejum9uZE6DUgT4vVLlUFRBWg==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-3.2.1.tgz",
+          "integrity": "sha512-EgDZ/Z7PxL2kCasKk7wnRkV8W9kvwuIlHuHXAxkQm3FF0MgVsjyLBXGjSRGhjE6u7rhSpk3KaMfFM23bfMysIQ==",
           "requires": {
             "ini": "^1.3.5",
             "node-gyp-build": "^4.2.0"
@@ -1667,9 +1667,9 @@
       }
     },
     "fd-lock": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/fd-lock/-/fd-lock-1.1.1.tgz",
-      "integrity": "sha512-Ng+IXbq6LPMDvvVb0Vr325NjqhPwqlLIvmf43ii7t3WQvo2sHU6V6jQY1cclflxPaPfvNUAuD5VdPuIO1sp50g==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fd-lock/-/fd-lock-1.2.0.tgz",
+      "integrity": "sha512-Lk/pKH2DldLpG4Yh/sOOY84k5VqNzxHPffGwf1+yYI+/qMXzTPp9KJMX+Wh6n4xqGSA1Mu7JPmaDArfJGw2O/A==",
       "optional": true,
       "requires": {
         "napi-macros": "^2.0.0",
@@ -1702,6 +1702,11 @@
       "requires": {
         "to-regex-range": "^5.0.1"
       }
+    },
+    "filter-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+      "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs="
     },
     "find-root": {
       "version": "1.1.0",
@@ -2132,25 +2137,25 @@
           }
         },
         "sodium-native": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-3.2.0.tgz",
-          "integrity": "sha512-8aq/vQSegLwsRch8Sb/Bpf9aAqlNe5dp0+NVhb9UjHv42zDZ0D5zX3wBRUbXK9Ejum9uZE6DUgT4vVLlUFRBWg==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-3.2.1.tgz",
+          "integrity": "sha512-EgDZ/Z7PxL2kCasKk7wnRkV8W9kvwuIlHuHXAxkQm3FF0MgVsjyLBXGjSRGhjE6u7rhSpk3KaMfFM23bfMysIQ==",
           "requires": {
             "ini": "^1.3.5",
             "node-gyp-build": "^4.2.0"
           }
         },
         "sodium-universal": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-3.0.3.tgz",
-          "integrity": "sha512-kSU3K6bN5r/c/hbaMnYpz5GCzj2hsVSoHvYI9TTln99YCfZn61IVxCYFu+ELQPvvks3PY1HcZbOzEogcU/7iRg==",
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-3.0.4.tgz",
+          "integrity": "sha512-WnBQ0GDo/82shKQHZBZT9h4q4miCtxkbzcwVLsCBPWNq4qbq8BXhKICt9nPwQAsJ43ct/rF61FKu4t0druUBug==",
           "requires": {
             "blake2b": "^2.1.1",
             "chacha20-universal": "^1.0.4",
             "nanoassert": "^2.0.0",
             "resolve": "^1.17.0",
-            "sha256-universal": "^1.0.1",
-            "sha512-universal": "^1.0.1",
+            "sha256-universal": "^1.1.0",
+            "sha512-universal": "^1.1.0",
             "siphash24": "^1.0.1",
             "sodium-javascript": "~0.7.2",
             "sodium-native": "^3.2.0",
@@ -2194,9 +2199,9 @@
       }
     },
     "hyperswarm": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/hyperswarm/-/hyperswarm-2.15.2.tgz",
-      "integrity": "sha512-4TrClGoKJWO+W3LV0bhFVqmt6iZvx4jU0lklqvfsWCXoI8WmdHDC1dXqxMvJlalA6HXJWctgbshKqz+CYUEbhg==",
+      "version": "2.15.3",
+      "resolved": "https://registry.npmjs.org/hyperswarm/-/hyperswarm-2.15.3.tgz",
+      "integrity": "sha512-bESly7s6X7cLMWCn4dsAVE/ttNbbB13o6jku2B7fV2wIV/g7NVC/yF7S3NiknGlftKn/uLU3fhMmbOfdBvQ5IA==",
       "requires": {
         "@hyperswarm/network": "^2.0.0",
         "shuffled-priority-queue": "^2.1.0",
@@ -2574,11 +2579,11 @@
       }
     },
     "k-bucket": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/k-bucket/-/k-bucket-5.0.0.tgz",
-      "integrity": "sha512-r/q+wV/Kde62/tk+rqyttEJn6h0jR7x+incdMVSYTqK73zVxVrzJa70kJL49cIKen8XjIgUZKSvk8ktnrQbK4w==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/k-bucket/-/k-bucket-5.1.0.tgz",
+      "integrity": "sha512-Fac7iINEovXIWU20GPnOMLUbjctiS+cnmyjC4zAUgvs3XPf1vo9akfCHkigftSic/jiKqKl+KA3a/vFcJbHyCg==",
       "requires": {
-        "randombytes": "^2.0.3"
+        "randombytes": "^2.1.0"
       }
     },
     "kappa-core": {
@@ -4083,28 +4088,29 @@
       "dev": true
     },
     "query-string": {
-      "version": "6.13.8",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.8.tgz",
-      "integrity": "sha512-jxJzQI2edQPE/NPUOusNjO/ZOGqr1o2OBa/3M00fU76FsLXDVbJDv/p7ng5OdQyorKrkRz1oqfwmbe5MAMePQg==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
+      "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
       "requires": {
         "decode-uri-component": "^0.2.0",
+        "filter-obj": "^1.1.0",
         "split-on-first": "^1.0.0",
         "strict-uri-encode": "^2.0.0"
       }
     },
     "random-access-file": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/random-access-file/-/random-access-file-2.1.4.tgz",
-      "integrity": "sha512-WAcBP5iLhg1pbjZA40WyMenjK7c5gJUY6Pi5HJ3fLJCeVFNSZv3juf20yFMKxBdvcX5GKbX/HZSfFzlLBdGTdQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/random-access-file/-/random-access-file-2.2.0.tgz",
+      "integrity": "sha512-B744003Mj7v3EcuPl9hCiB2Ot4aZjgtU2mV6yFY1THiWU/XfGf1uSadR+SlQdJcwHgAWeG7Lbos0aUqjtj8FQg==",
       "requires": {
         "mkdirp-classic": "^0.5.2",
         "random-access-storage": "^1.1.1"
       }
     },
     "random-access-memory": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/random-access-memory/-/random-access-memory-3.1.1.tgz",
-      "integrity": "sha512-Qy1MliJDozZ1A6Hx3UbEnm8PPCfkiG/8CArbnhrxXMx1YRJPWipgPTB9qyhn4Z7WlLvCEqPb6Bd98OayyVuwrA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/random-access-memory/-/random-access-memory-3.1.2.tgz",
+      "integrity": "sha512-wIfh4OZ9T+FRNf6rbXLvEb4FfSxyZpvGnC5kC7Xi39SyPkRYfeJyR9Xwa13iLbNyoNKNIkTFUE4g9lXFb1ZflA==",
       "requires": {
         "inherits": "^2.0.3",
         "is-options": "^1.0.1",
@@ -4733,19 +4739,11 @@
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "streamx": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.10.0.tgz",
-      "integrity": "sha512-yRWWgVtnVRePoNxkrU4StupcZ3GplpIR6COGLnTBDgS19SqB0aK8L572lw5g1SenmZHsRr/qBZWfZbnIBiK88A==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.10.2.tgz",
+      "integrity": "sha512-+HETj2wSTg4DLSp6f6UjYnxP0K8skeN8dEie/tbDR2cTX6bj9HNa0g9iSZY/jXowG629al0cq/3zLNlFUKSh7g==",
       "requires": {
-        "fast-fifo": "^1.0.0",
-        "nanoassert": "^2.0.0"
-      },
-      "dependencies": {
-        "nanoassert": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-2.0.0.tgz",
-          "integrity": "sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA=="
-        }
+        "fast-fifo": "^1.0.0"
       }
     },
     "strftime": {
@@ -5116,9 +5114,9 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utp-native": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/utp-native/-/utp-native-2.2.2.tgz",
-      "integrity": "sha512-xwn5neM3aKgRCNYaiENRf2pwPa2G79O7r+OCZJDiy92x2q58Ez9hFUPeAW0IQcv0Ii5l1ytDIFWWyaiYVOtlng==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/utp-native/-/utp-native-2.3.0.tgz",
+      "integrity": "sha512-5dV711teCP21FIRndcq44ETDPL00TnRVmEnINu3jxyg0tq//ptxOyq7oNO6TcMmuFfeFZRSYOqDmTUl8MmPauQ==",
       "requires": {
         "napi-macros": "^2.0.0",
         "node-gyp-build": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "ansi-escapes": "^4.3.1",
-    "cabal-client": "^6.2.7",
+    "cabal-client": "^6.3.0",
     "chalk": "^4.0.0",
     "js-yaml": "^3.13.1",
     "minimist": "^1.2.5",

--- a/views.js
+++ b/views.js
@@ -145,6 +145,7 @@ function renderHorizontalLine (chr, width, chlk) {
 function renderNicks (state, width, height) {
   // All known users
   var users = state.cabal.getChannelMembers()
+  const currentChannel = state.cabal.getCurrentChannel()
   users = Object.keys(users)
     .map(key => users[key])
     .sort(util.cmpUser)
@@ -179,15 +180,15 @@ function renderNicks (state, width, height) {
       // Duplicate nick count
       const duplicates = user.online ? onlineNickCount[name] : offlineNickCount[name]
       const dupecountStr = `(${duplicates})`
-      const modSigilLength = (user.isAdmin() || user.isModerator() || user.isHidden()) ? 1 : 0
+      const modSigilLength = (user.isAdmin(currentChannel) || user.isModerator(currentChannel) || user.isHidden(currentChannel)) ? 1 : 0
       outputName = util.sanitizeString(name).slice(0, width - modSigilLength)
       if (duplicates > 1) outputName = outputName.slice(0, width - dupecountStr.length - 2 - modSigilLength)
 
       // Colorize
       let colorizedName = outputName.slice()
-      if (user.isAdmin()) colorizedName = chalk.green('@') + colorizedName
-      else if (user.isModerator()) colorizedName = chalk.green('%') + colorizedName
-      else if (user.isHidden()) colorizedName = chalk.green('-') + colorizedName
+      if (user.isAdmin(currentChannel)) colorizedName = chalk.green('@') + colorizedName
+      else if (user.isModerator(currentChannel)) colorizedName = chalk.green('%') + colorizedName
+      else if (user.isHidden(currentChannel)) colorizedName = chalk.green('-') + colorizedName
       if (user.online) {
         colorizedName = chalk.bold(colorizedName)
       }

--- a/views.js
+++ b/views.js
@@ -8,11 +8,19 @@ const HEADER_ROWS = 8
 const NICK_COLS = 15
 const CHAN_COLS = 16
 
-module.exports = { big, small, getPageSize }
+module.exports = { big, small, getPageSize, getChatWidth }
 
 function getPageSize () {
   return process.stdout.rows - HEADER_ROWS
 }
+
+function getChatWidth () {
+  if (process.stdout.columns > 80) {
+    return process.stdout.columns - NICK_COLS - CHAN_COLS - 2 /* 2x vertical dividers */ - 1 /* nick col padding */
+  }
+  return process.stdout.columns
+}
+
 
 function small (state) {
   var screen = []
@@ -200,7 +208,6 @@ function renderNicks (state, width, height) {
   state.userScrollback = Math.min(state.userScrollback, formattedNicks.length - height)
   if (formattedNicks.length < height) state.userScrollback = 0
   var nickBlock = formattedNicks.slice(state.userScrollback, state.userScrollback + height)
-
   return nickBlock
 }
 

--- a/views.js
+++ b/views.js
@@ -21,7 +21,6 @@ function getChatWidth () {
   return process.stdout.columns
 }
 
-
 function small (state) {
   var screen = []
   var titlebarSize = Math.ceil(linkSize(state) / process.stdout.columns)


### PR DESCRIPTION
This PR brings cabal-cli in line with the upstream [cabal-client](https://github.com/cabal-club/cabal-client/) changes outlined in https://github.com/cabal-club/cabal-client/pull/73 https://github.com/cabal-club/cabal-client/pull/69

The changes:
* moderation commands can now be applied on a channel-by-channel basis, in addition to a cabal-wide basis
* events emitted from cabal-client wrt slash-commands have had a slightly changed structure, which this PR adds support for
* added support for displaying [channel archiving & unarchiving events](https://github.com/cabal-club/cabal-core/pull/103)