### PR TITLE
add /more: increases backlog for current channel

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -157,6 +157,13 @@ const client = new Client({
   },
   commands: {
     // todo: custom commands
+    more: {
+      help: () => 'adds more messages to the backlog of current channel',
+      category: ['misc'],
+      call: (cabal, res, arg) => {
+        fe.moreBacklog()
+      }
+    },
     panes: {
       help: () => 'set pane to navigate up and down in. panes: channels, cabals',
       category: ['misc'],


### PR DESCRIPTION
i felt a bit antsy about not wanting to post too many messages in a channel discussion, cause i wanted people not there to be able to get the full context of what was going on. quick hack: load more backlog manually with the `/more` command!

hm just realized this could probably be triggered when scrolling up && not loading any new messages (instead of manually with this command; might be more work hidden somewhere tho)

anyway here's a quick hack in the meantime :):):)