### PR TITLE
Add private message support

### DIFF
--- a/neat-screen.js
+++ b/neat-screen.js
@@ -424,7 +424,7 @@ NeatScreen.prototype.registerUpdateHandler = function (cabal) {
     this.client.addStatusMessage({ text:  chalk.magentaBright(text) })
   })
     
-  cabal.on("publish-private-message", ({ message }) => {
+  cabal.on("publish-private-message", message => {
     // don't display the notification if we're already looking at the pm it came from
     if (cabal.getCurrentChannel() === message.content.channel) { return }
     const users = cabal.getUsers()

--- a/neat-screen.js
+++ b/neat-screen.js
@@ -256,7 +256,7 @@ function NeatScreen (props) {
       if (i < 0) i += this.state.cabals.length
       setCabalByIndex.bind(this)(i)
     } else {
-      var channels = this.state.cabal.getJoinedChannels()
+      var channels = this.state.cabal.getChannels({ includePM: true })
       i = channels.indexOf(this.state.cabal.getCurrentChannel())
       i += dir * 1
       i = i % channels.length
@@ -271,7 +271,7 @@ function NeatScreen (props) {
   }
 
   function setChannelByIndex (n) {
-    var channels = self.state.cabal.getJoinedChannels()
+    var channels = self.state.cabal.getChannels({ includePM: true })
     if (n < 0 || n >= channels.length) return
     self.loadChannel(channels[n])
   }
@@ -412,6 +412,32 @@ NeatScreen.prototype.registerUpdateHandler = function (cabal) {
   }
   cabal.on('channel-archive', (envelope) => { processChannelArchiving('archive', envelope) })
   cabal.on('channel-unarchive', (envelope) => { processChannelArchiving('unarchive', envelope) })
+
+  cabal.on("private-message", (envelope) => {
+    // never display PMs inline from a hidden user
+    if (envelope.author.isHidden()) return
+    // don't display the notif if we're just sending something to ourselves (covered by publish-private-message event)
+    if (envelope.author.key === cabal.getLocalUser().key) return
+    // don't display the notification if we're already looking at the pm it came from
+    if (cabal.getCurrentChannel() === envelope.channel) { return }
+    const text = `PM [${envelope.author.name}]: ${envelope.message.value.content.text}`
+    this.client.addStatusMessage({ text:  chalk.magentaBright(text) })
+  })
+    
+  cabal.on("publish-private-message", ({ message }) => {
+    // don't display the notification if we're already looking at the pm it came from
+    if (cabal.getCurrentChannel() === message.content.channel) { return }
+    const users = cabal.getUsers()
+    const pubkey = message.content.channel
+    let name = pubkey.slice(0, 8)
+    if (pubkey in users) {
+    // never display PMs inline from a hidden user
+      if (users[pubkey].isHidden()) return
+      name = users[pubkey].name
+    }
+    const text = `PM to [${name}]: ${message.content.text}`
+    this.client.addStatusMessage({ text:  chalk.magentaBright(text) })
+  })
 }
 
 NeatScreen.prototype._pagesize = function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,21 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
+    "@geut/discovery-swarm-webrtc": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@geut/discovery-swarm-webrtc/-/discovery-swarm-webrtc-4.3.1.tgz",
+      "integrity": "sha512-PVm8d6SRZRjNXI2J4kbRuaOBwABq1FW6wD5ivWxKnwycAJTD2bk0EAylFfZMd7cZL6xgaICCLUpnFJhlOagOww==",
+      "requires": {
+        "debug": "^4.1.1",
+        "end-of-stream": "^1.4.4",
+        "minimist": "^1.2.0",
+        "mostly-minimal-spanning-tree": "^1.0.2",
+        "nanocustomassert": "^1.0.0",
+        "nanoerror": "^1.1.0",
+        "pump": "^3.0.0",
+        "socket-signal-websocket": "^9.1.0"
+      }
+    },
     "@hyperswarm/dht": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@hyperswarm/dht/-/dht-4.0.1.tgz",
@@ -162,6 +177,34 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.3",
         "fastq": "^1.6.0"
+      }
+    },
+    "@sammacbeth/random-access-idb-mutable-file": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@sammacbeth/random-access-idb-mutable-file/-/random-access-idb-mutable-file-0.1.1.tgz",
+      "integrity": "sha512-jHnpuu2qtFgwCmhgrpCCk3/hU3XqXTqhidh4XmcTijkVsGwh1c2T0+r2hkHs1PRfsxeimx8qDAotphpRoYB2eg==",
+      "requires": {
+        "buffer": "5.1.0",
+        "random-access-storage": "1.3.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.1.0.tgz",
+          "integrity": "sha512-YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        },
+        "random-access-storage": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/random-access-storage/-/random-access-storage-1.3.0.tgz",
+          "integrity": "sha512-pdS9Mcb9TB7oICypPRALlheaSuszuAKmLVEPKJMuYor7R/zDuHh5ALuQoS+ox31XRwQUL+tDwWH2GPdyspwelA==",
+          "requires": {
+            "inherits": "^2.0.3"
+          }
+        }
       }
     },
     "@types/color-name": {
@@ -324,6 +367,11 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
+    "async-limiter": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -484,37 +532,6 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
-    "bulk-write-stream": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/bulk-write-stream/-/bulk-write-stream-1.1.4.tgz",
-      "integrity": "sha512-GtKwd/4etuk1hNeprXoESBO1RSeRYJMXKf+O0qHmWdUomLT8ysNEfX/4bZFXr3BK6eukpHiEnhY2uMtEHDM2ng==",
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.1.4"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        }
-      }
-    },
     "byline": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
@@ -522,11 +539,11 @@
       "dev": true
     },
     "cabal-client": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/cabal-client/-/cabal-client-6.3.1.tgz",
-      "integrity": "sha512-+TJujTN5lwx2kRkqoyhajTCnkNT1nYb59qGWFTwLbVkaO2pQT5DZw+ZY6lN3VYCJaV3rsumm7c0GS4K94OmDAg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/cabal-client/-/cabal-client-7.2.0.tgz",
+      "integrity": "sha512-PQaydHnAU0gm3HvzkzC8mhlHtfjou30D7liRWgpVB2E5J3l2QBRBCpN9hkBq8b0x1Dgsux19cbdCJOo/xzhv4w==",
       "requires": {
-        "cabal-core": "^13.2.0",
+        "cabal-core": "^15.0.0",
         "collect-stream": "^1.2.1",
         "dat-dns": "^4.1.2",
         "debug": "^4.1.1",
@@ -535,55 +552,259 @@
         "memdb": "^1.3.1",
         "mkdirp": "^1.0.4",
         "monotonic-timestamp": "0.0.9",
-        "paperslip": "^3.0.0",
+        "paperslip": "^3.1.0",
         "pump": "^3.0.0",
         "qrcode": "^1.4.4",
         "random-access-memory": "^3.1.1",
+        "random-access-web": "^2.0.3",
         "strftime": "^0.10.0",
         "to2": "^1.0.0"
+      },
+      "dependencies": {
+        "cabal-core": {
+          "version": "15.0.0",
+          "resolved": "https://registry.npmjs.org/cabal-core/-/cabal-core-15.0.0.tgz",
+          "integrity": "sha512-znwgdYgBMDhpSqPUbWRrhfEtq6vDC5PxsXaYfLs2nMzLxOCAFe2aI4jbqaMSZMkfNIF9ONFPcd1HsVGFI8mZww==",
+          "requires": {
+            "charwise": "^3.0.1",
+            "collect-stream": "^1.2.1",
+            "debug": "^4.1.1",
+            "duplexify": "^4.1.1",
+            "hypercore-crypto": "^2.1.1",
+            "hyperswarm": "^2.13.0",
+            "hyperswarm-web": "^2.1.1",
+            "inherits": "^2.0.4",
+            "kappa-core": "^7.0.0",
+            "kappa-view": "^3.1.0",
+            "kappa-view-level": "^2.0.1",
+            "level-mem": "^5.0.1",
+            "materialized-group-auth": "^2.1.0",
+            "monotonic-timestamp": "0.0.9",
+            "once": "^1.4.0",
+            "private-box": "^0.3.1",
+            "pump": "^3.0.0",
+            "read-only-stream": "^2.0.0",
+            "readable-stream": "^3.4.0",
+            "sodium-universal": "^3.0.4",
+            "subleveldown": "^4.1.0",
+            "through2": "^3.0.1",
+            "thunky": "^1.0.3",
+            "xtend": "^4.0.1"
+          }
+        }
       }
     },
     "cabal-core": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/cabal-core/-/cabal-core-13.2.0.tgz",
-      "integrity": "sha512-l6lCDO/nisragg5gkjGJ/vzPL1Nu+u+SUlrg2PN5vaeGntbnVsADaQo88L5p63RuU1nW53dWdICyyeE5h/kuJg==",
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/cabal-core/-/cabal-core-14.1.2.tgz",
+      "integrity": "sha512-is3x9Sjpon1ZMnwhk4QZp+K5BA7D5mWvX6kdRi5073HrKDDA0jvMTRRgABOcCD6/bIKzlKEJfkzFSyulmPZqig==",
       "requires": {
         "charwise": "^3.0.1",
         "collect-stream": "^1.2.1",
-        "concat-stream": "^2.0.0",
-        "dat-encoding": "^5.0.1",
         "debug": "^4.1.1",
         "duplexify": "^4.1.1",
-        "hypercore-crypto": "^1.0.0",
+        "hypercore-crypto": "^2.1.1",
         "hyperswarm": "^2.13.0",
+        "hyperswarm-web": "^2.1.1",
         "inherits": "^2.0.4",
-        "kappa-core": "^6.0.0",
+        "kappa-core": "^7.0.0",
+        "kappa-view": "^3.1.0",
         "kappa-view-level": "^2.0.1",
         "level-mem": "^5.0.1",
         "materialized-group-auth": "^2.1.0",
         "monotonic-timestamp": "0.0.9",
         "once": "^1.4.0",
+        "private-box": "^0.3.1",
         "pump": "^3.0.0",
-        "query-string": "^6.8.2",
-        "randombytes": "^2.0.6",
         "read-only-stream": "^2.0.0",
         "readable-stream": "^3.4.0",
-        "strftime": "^0.10.0",
+        "sodium-universal": "^3.0.4",
         "subleveldown": "^4.1.0",
         "through2": "^3.0.1",
         "thunky": "^1.0.3",
         "xtend": "^4.0.1"
       },
       "dependencies": {
-        "hypercore-crypto": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/hypercore-crypto/-/hypercore-crypto-1.0.0.tgz",
-          "integrity": "sha512-xFwOnNlOt8L+SovC7dTNchKaNYJb5l8rKZZwpWQnCme1r7CU4Hlhp1RDqPES6b0OpS7DkTo9iU0GltQGkpsjMw==",
+        "hmac-blake2b": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/hmac-blake2b/-/hmac-blake2b-2.0.0.tgz",
+          "integrity": "sha512-JbGNtM1YRd8EQH/2vNTAP1oy5lJVPlBFYZfCJTu3k8sqOUm0rRIf/3+MCd5noVykETwTbun6jEOc+4Tu78ubHA==",
           "requires": {
-            "buffer-alloc-unsafe": "^1.1.0",
-            "buffer-from": "^1.1.0",
-            "sodium-universal": "^2.0.0",
-            "uint64be": "^2.0.2"
+            "nanoassert": "^1.1.0",
+            "sodium-native": "^3.1.1",
+            "sodium-universal": "^3.0.0"
+          },
+          "dependencies": {
+            "nanoassert": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-1.1.0.tgz",
+              "integrity": "sha1-TzFS4JVA/eKMdvRLGbvNHVpCR40="
+            }
+          }
+        },
+        "hypercore": {
+          "version": "9.12.0",
+          "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-9.12.0.tgz",
+          "integrity": "sha512-wIlM4Iwl618NcmsY+1O/X08Cx/bY6ti3LXmQhRnPZFGQPqAeX0x53hASckW082IIAVWzXD3zcmREw5yEINzb4w==",
+          "requires": {
+            "abstract-extension": "^3.0.1",
+            "atomic-batcher": "^1.0.2",
+            "bitfield-rle": "^2.2.1",
+            "codecs": "^2.0.0",
+            "fast-bitfield": "^1.2.2",
+            "flat-tree": "^1.6.0",
+            "hypercore-cache": "^1.0.1",
+            "hypercore-crypto": "^2.0.0",
+            "hypercore-default-storage": "^1.1.1",
+            "hypercore-protocol": "^8.0.5",
+            "hypercore-streams": "^1.0.1",
+            "inherits": "^2.0.3",
+            "inspect-custom-symbol": "^1.1.0",
+            "last-one-wins": "^1.0.4",
+            "memory-pager": "^1.0.2",
+            "merkle-tree-stream": "^4.0.0",
+            "nanoguard": "^1.2.0",
+            "nanoresource": "^1.3.0",
+            "pretty-hash": "^1.0.1",
+            "sparse-bitfield": "^3.0.0",
+            "timeout-refresh": "^1.0.3",
+            "uint64be": "^2.0.1",
+            "unordered-array-remove": "^1.0.2",
+            "unordered-set": "^2.0.0"
+          }
+        },
+        "hypercore-protocol": {
+          "version": "8.0.7",
+          "resolved": "https://registry.npmjs.org/hypercore-protocol/-/hypercore-protocol-8.0.7.tgz",
+          "integrity": "sha512-b5TXhqXUZ+Z7M/5/PlCTgElfufDRa3EzACd7y7BA7owLkxQreaUQ58wUO7nzJppDP1bnC2Hz6Hg7nlRPc75bKw==",
+          "requires": {
+            "abstract-extension": "^3.0.1",
+            "debug": "^4.1.1",
+            "hypercore-crypto": "^2.0.0",
+            "inspect-custom-symbol": "^1.1.0",
+            "nanoguard": "^1.2.1",
+            "pretty-hash": "^1.0.1",
+            "simple-hypercore-protocol": "^2.0.0",
+            "streamx": "^2.1.0",
+            "timeout-refresh": "^1.0.0"
+          }
+        },
+        "kappa-core": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/kappa-core/-/kappa-core-7.0.0.tgz",
+          "integrity": "sha512-JAqz9BzAeCb2K2JeUL9ii6BcdXtinRmcWXiPl0KTfI96NRZhLlylObhL+pNvqnlEOfKumpJNB+Tzdxg66/AzQA==",
+          "requires": {
+            "inherits": "^2.0.4",
+            "multifeed": "^6.0.0",
+            "multifeed-index": "^3.3.2"
+          }
+        },
+        "merkle-tree-stream": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/merkle-tree-stream/-/merkle-tree-stream-4.0.0.tgz",
+          "integrity": "sha512-TIurLf/ustQNMXi5foClGTcEsRvH6DCvxeAKu68OrwHMOSM/M1pgPXb7qe52Svk1ClvmZuAVpLtP5FWKzPr/sw==",
+          "requires": {
+            "flat-tree": "^1.3.0",
+            "streamx": "^2.7.1"
+          }
+        },
+        "multifeed": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/multifeed/-/multifeed-6.0.0.tgz",
+          "integrity": "sha512-PuK9zBYr7lu0WwkDE9kq1523ECi1vOFzS20CHG+2d1ZaGPARNrsGBzYPUvwTueAWpBJPxbpfmR5FORgYQemcOw==",
+          "requires": {
+            "debug": "^4.1.0",
+            "hypercore": "^9.6.0",
+            "hypercore-protocol": "^8.0.7",
+            "inherits": "^2.0.3",
+            "mutexify": "^1.2.0",
+            "once": "^1.4.0",
+            "random-access-file": "^2.0.1",
+            "random-access-memory": "^3.1.1",
+            "through2": "^3.0.0"
+          }
+        },
+        "nanoassert": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-2.0.0.tgz",
+          "integrity": "sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA=="
+        },
+        "node-gyp-build": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+          "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q=="
+        },
+        "noise-protocol": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/noise-protocol/-/noise-protocol-3.0.1.tgz",
+          "integrity": "sha512-4rQGZvismeb4tMf91O31oDYLGntkEs4p4wa69+14juHTV4A3COtWyDck9PwBqFjg7S8TPZLCUXUdOnOZQJ5UBA==",
+          "requires": {
+            "clone": "^2.1.2",
+            "hmac-blake2b": "^2.0.0",
+            "nanoassert": "^2.0.0",
+            "sodium-universal": "^3.0.2"
+          }
+        },
+        "simple-handshake": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/simple-handshake/-/simple-handshake-3.0.0.tgz",
+          "integrity": "sha512-8Te0vlxvhpNCMgwnWFTbRR6Re2l8hq8wyXQc3lY9dPYXFxYwVkh79LhDQHFCOWRavmbiOdfqq1l5HT/73Rn2/w==",
+          "requires": {
+            "nanoassert": "^2.0.0",
+            "noise-protocol": "^3.0.0"
+          }
+        },
+        "simple-hypercore-protocol": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/simple-hypercore-protocol/-/simple-hypercore-protocol-2.1.2.tgz",
+          "integrity": "sha512-zCwEMw/Evd5iDPkVEjO+1T3OJqbuDukJSuZtMZ7A7Wfn0RxmaJFbwngfUnDNyQFbPMxiINNxGBMD85fFJF8ghA==",
+          "requires": {
+            "hypercore-crypto": "^2.1.0",
+            "noise-protocol": "^3.0.1",
+            "protocol-buffers-encodings": "^1.1.0",
+            "simple-handshake": "^3.0.0",
+            "simple-message-channels": "^1.2.1",
+            "varint": "^5.0.0",
+            "xsalsa20-universal": "^1.0.0"
+          }
+        },
+        "sodium-javascript": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/sodium-javascript/-/sodium-javascript-0.7.3.tgz",
+          "integrity": "sha512-J2Zzj61bo41oBO4yEM9hTaNo3J98AcmFctjRg3D7+0A5cXdB1jlQOHV1qo2NavDU3BpqCfxdHW5UXCv565zh6Q==",
+          "requires": {
+            "blake2b": "^2.1.1",
+            "chacha20-universal": "^1.0.4",
+            "nanoassert": "^2.0.0",
+            "sha256-universal": "^1.1.0",
+            "sha512-universal": "^1.1.0",
+            "siphash24": "^1.0.1",
+            "xsalsa20": "^1.0.0"
+          }
+        },
+        "sodium-native": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-3.3.0.tgz",
+          "integrity": "sha512-rg6lCDM/qa3p07YGqaVD+ciAbUqm6SoO4xmlcfkbU5r1zIGrguXztLiEtaLYTV5U6k8KSIUFmnU3yQUSKmf6DA==",
+          "requires": {
+            "node-gyp-build": "^4.3.0"
+          }
+        },
+        "sodium-universal": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-3.0.4.tgz",
+          "integrity": "sha512-WnBQ0GDo/82shKQHZBZT9h4q4miCtxkbzcwVLsCBPWNq4qbq8BXhKICt9nPwQAsJ43ct/rF61FKu4t0druUBug==",
+          "requires": {
+            "blake2b": "^2.1.1",
+            "chacha20-universal": "^1.0.4",
+            "nanoassert": "^2.0.0",
+            "resolve": "^1.17.0",
+            "sha256-universal": "^1.1.0",
+            "sha512-universal": "^1.1.0",
+            "siphash24": "^1.0.1",
+            "sodium-javascript": "~0.7.2",
+            "sodium-native": "^3.2.0",
+            "xsalsa20": "^1.0.0"
           }
         }
       }
@@ -668,6 +889,42 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/charwise/-/charwise-3.0.1.tgz",
       "integrity": "sha512-RcdumNsM6fJZ5HHbYunqj2bpurVRGsXour3OR+SlLEHFhG6ALm54i6Osnh+OvO7kEoSBzwExpblYFH8zKQiEPw=="
+    },
+    "chloride": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chloride/-/chloride-2.4.1.tgz",
+      "integrity": "sha512-ZiID87W2o2llvuF4C7Fvt9GJisazSdMsSkjAq4WaMed9zn77nlkcy08ZfrPtOGAXyaxTDj0VjnuyD97EdJLz3g==",
+      "requires": {
+        "sodium-browserify": "^1.2.7",
+        "sodium-browserify-tweetnacl": "^0.2.5",
+        "sodium-chloride": "^1.1.2",
+        "sodium-native": "^3.0.0"
+      },
+      "dependencies": {
+        "node-gyp-build": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+          "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
+          "optional": true
+        },
+        "sodium-native": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-3.3.0.tgz",
+          "integrity": "sha512-rg6lCDM/qa3p07YGqaVD+ciAbUqm6SoO4xmlcfkbU5r1zIGrguXztLiEtaLYTV5U6k8KSIUFmnU3yQUSKmf6DA==",
+          "optional": true,
+          "requires": {
+            "node-gyp-build": "^4.3.0"
+          }
+        }
+      }
+    },
+    "chloride-test": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/chloride-test/-/chloride-test-1.2.4.tgz",
+      "integrity": "sha512-9vhoi1qXSBPn6//ZxIgSe3M2QhKHzIPZQzmrZgmPADsqW0Jxpe3db1e7aGSRUMXbxAQ04SfypdT8dGaSvIvKDw==",
+      "requires": {
+        "json-buffer": "^2.0.11"
+      }
     },
     "chokidar": {
       "version": "3.3.0",
@@ -800,14 +1057,35 @@
       "dev": true
     },
     "concat-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
-      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
-        "readable-stream": "^3.0.2",
+        "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
       }
     },
     "contains-path": {
@@ -883,46 +1161,6 @@
         "call-me-maybe": "^1.0.1",
         "concat-stream": "^1.6.0",
         "debug": "^4.1.1"
-      },
-      "dependencies": {
-        "concat-stream": {
-          "version": "1.6.2",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-          "requires": {
-            "buffer-from": "^1.0.0",
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.2.2",
-            "typedarray": "^0.0.6"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        }
-      }
-    },
-    "dat-encoding": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/dat-encoding/-/dat-encoding-5.0.1.tgz",
-      "integrity": "sha512-PET9PlGt6ejgqU07hbPLx3tP2siDMMFumUe+xwmm4+5W+0cOlpzreCPoMVUBzxWeR4sPdxL+AS53odQTBtzEqA==",
-      "requires": {
-        "safe-buffer": "^5.0.1"
       }
     },
     "debug": {
@@ -943,11 +1181,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
-    },
-    "decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "dedent": {
       "version": "0.7.0",
@@ -1011,11 +1244,26 @@
         "uniq": "^1.0.1"
       }
     },
+    "delay": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-4.4.1.tgz",
+      "integrity": "sha512-aL3AhqtfhOlT/3ai6sWXeqwnw63ATNpnUiN4HL7x9q+My5QtHlO3OIkasmug9LKzpheLdmUKGRKnYXYAS7FQkQ=="
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "dht-rpc": {
       "version": "4.9.6",
@@ -1061,9 +1309,9 @@
       }
     },
     "dijkstrajs": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.1.tgz",
-      "integrity": "sha1-082BIh4+pAdCz83lVtTpnpjdxxs="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.2.tgz",
+      "integrity": "sha512-QV6PMaHTCNmKSeP6QoXhVTw9snc9VD8MulTT0Bd99Pacp4SS1cjcrYPgBPmibqKVtMJJfqC6XvOXgPMEEPH/fg=="
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -1093,14 +1341,43 @@
       }
     },
     "duplexify": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.1.tgz",
-      "integrity": "sha512-DY3xVEmVHTv1wSzKNbwoU6nVjzI369Y6sPoqfYr0/xlx3IdX2n94xIszTcjPO8W8ZIv0Wb0PXNcjuZyT4wiICA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
       "requires": {
         "end-of-stream": "^1.4.1",
         "inherits": "^2.0.3",
         "readable-stream": "^3.1.1",
         "stream-shift": "^1.0.0"
+      }
+    },
+    "duplexpair": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/duplexpair/-/duplexpair-1.0.1.tgz",
+      "integrity": "sha512-xAJCL8UnXa+GyHIqSNUT9eiQSfGvSBPOZvAYN17ULwYBMady5Ek6Ghpuj4P6+ZGkjlmUFdTh9y+ejvKRl5rcRg==",
+      "requires": {
+        "readable-stream": "^2.3.3"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
       }
     },
     "ecc-jsbn": {
@@ -1113,10 +1390,33 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "ed2curve": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/ed2curve/-/ed2curve-0.1.4.tgz",
+      "integrity": "sha1-lKRCSLuH2jXbDv968KpXYWgRf1k=",
+      "requires": {
+        "tweetnacl": "0.x.x"
+      }
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "emittery": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.6.0.tgz",
+      "integrity": "sha512-6EMRGr9KzYWp8DzHFZsKVZBsMO6QhAeHMeHND8rhyBNCHKMLpgW9tZv40bwN3rAIKRS5CxcK8oLRKUJSB9h7yQ=="
+    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "encoding-down": {
       "version": "6.3.0",
@@ -1136,6 +1436,19 @@
       "requires": {
         "once": "^1.4.0"
       }
+    },
+    "end-of-stream-promise": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/end-of-stream-promise/-/end-of-stream-promise-1.0.0.tgz",
+      "integrity": "sha512-1u3Geul15xPtCiZFZibKWulA6pMecvPO+cvejugP36fGviKdcKydXzHMLqjZgt+N+DO+ifcKVUYcmg7IxlgpBg==",
+      "requires": {
+        "end-of-stream": "^1.4.4"
+      }
+    },
+    "err-code": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
+      "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="
     },
     "errno": {
       "version": "0.1.8",
@@ -1183,6 +1496,11 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -1583,6 +1901,16 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
     "expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -1661,19 +1989,8 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
       "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
-      "dev": true,
       "requires": {
         "reusify": "^1.0.4"
-      }
-    },
-    "fd-lock": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fd-lock/-/fd-lock-1.2.0.tgz",
-      "integrity": "sha512-Lk/pKH2DldLpG4Yh/sOOY84k5VqNzxHPffGwf1+yYI+/qMXzTPp9KJMX+Wh6n4xqGSA1Mu7JPmaDArfJGw2O/A==",
-      "optional": true,
-      "requires": {
-        "napi-macros": "^2.0.0",
-        "node-gyp-build": "^4.2.2"
       }
     },
     "figures": {
@@ -1702,11 +2019,6 @@
       "requires": {
         "to-regex-range": "^5.0.1"
       }
-    },
-    "filter-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-      "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs="
     },
     "find-root": {
       "version": "1.1.0",
@@ -1754,9 +2066,9 @@
       }
     },
     "flat-tree": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/flat-tree/-/flat-tree-1.8.0.tgz",
-      "integrity": "sha512-VIdjqvARJGq1V+EhT18prwhrR4McbY2M6iH1vyKTgewfQtpyd1jhLXcnQJFZZDKBhpJM8zCB2kLQEiy51bhcOw=="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/flat-tree/-/flat-tree-1.9.0.tgz",
+      "integrity": "sha512-WRu5/q9fcdL9f7L6Ahq8fR153e5Zr5aU6plPHupN6JDWuvEJbMjrEQprge3/I7ytndHC6/GUNg5Rg8XEisuv5w=="
     },
     "flatted": {
       "version": "2.0.2",
@@ -1811,10 +2123,16 @@
         "mime-types": "^2.1.12"
       }
     },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+    },
     "from2": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
@@ -1824,6 +2142,7 @@
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -1837,12 +2156,14 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
         },
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -1866,6 +2187,16 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "fsctl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fsctl/-/fsctl-1.0.0.tgz",
+      "integrity": "sha512-uNHlfhyUJiVO2kHA6ZBnDkBhG1wM8fII+xGfCi5aBoWR7DLh9Q3nOAWe4fEETQzkptahITI1xbe5r23HuA5ECA==",
+      "optional": true,
+      "requires": {
+        "napi-macros": "^2.0.0",
+        "node-gyp-build": "^4.2.3"
+      }
+    },
     "fsevents": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
@@ -1883,6 +2214,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+    },
+    "get-browser-rtc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-browser-rtc/-/get-browser-rtc-1.1.0.tgz",
+      "integrity": "sha512-MghbMJ61EJrRsDe7w1Bvqt3ZsBuqhce5nrn/XAwgwOXhcsz53/ltdxOse1h/8eKXj5slzxdsz56g5rzOFSGwfQ=="
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -2023,12 +2359,13 @@
       "dev": true
     },
     "hmac-blake2b": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/hmac-blake2b/-/hmac-blake2b-0.2.0.tgz",
-      "integrity": "sha512-cJpnWOYMtaLr+3O32OII7DSTmQh+BKoeLXw49UAIc2QU68UwD2iBjItwxRVHmu1GBTuHeqME+rq7GpW2rBncCQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hmac-blake2b/-/hmac-blake2b-2.0.0.tgz",
+      "integrity": "sha512-JbGNtM1YRd8EQH/2vNTAP1oy5lJVPlBFYZfCJTu3k8sqOUm0rRIf/3+MCd5noVykETwTbun6jEOc+4Tu78ubHA==",
       "requires": {
         "nanoassert": "^1.1.0",
-        "sodium-universal": "^2.0.0"
+        "sodium-native": "^3.1.1",
+        "sodium-universal": "^3.0.0"
       }
     },
     "hosted-git-info": {
@@ -2036,6 +2373,18 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
       "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
       "dev": true
+    },
+    "http-errors": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+      "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      }
     },
     "http-signature": {
       "version": "1.2.0",
@@ -2057,50 +2406,34 @@
       }
     },
     "hypercore": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-8.14.0.tgz",
-      "integrity": "sha512-UIW0qSjBzQL4Z9tN97kBxM85JJsQL9osA6FWD9BYB/UKPD+umGgrocaN3kM9l3g2yKe/ziFU0DP5ys+qgqYIdQ==",
+      "version": "9.12.0",
+      "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-9.12.0.tgz",
+      "integrity": "sha512-wIlM4Iwl618NcmsY+1O/X08Cx/bY6ti3LXmQhRnPZFGQPqAeX0x53hASckW082IIAVWzXD3zcmREw5yEINzb4w==",
       "requires": {
         "abstract-extension": "^3.0.1",
         "atomic-batcher": "^1.0.2",
         "bitfield-rle": "^2.2.1",
-        "bulk-write-stream": "^1.1.3",
         "codecs": "^2.0.0",
         "fast-bitfield": "^1.2.2",
-        "fd-lock": "^1.0.2",
         "flat-tree": "^1.6.0",
-        "from2": "^2.3.0",
         "hypercore-cache": "^1.0.1",
-        "hypercore-crypto": "^1.0.0",
-        "hypercore-protocol": "^7.9.0",
+        "hypercore-crypto": "^2.0.0",
+        "hypercore-default-storage": "^1.1.1",
+        "hypercore-protocol": "^8.0.5",
+        "hypercore-streams": "^1.0.1",
         "inherits": "^2.0.3",
         "inspect-custom-symbol": "^1.1.0",
         "last-one-wins": "^1.0.4",
         "memory-pager": "^1.0.2",
-        "merkle-tree-stream": "^3.0.3",
+        "merkle-tree-stream": "^4.0.0",
         "nanoguard": "^1.2.0",
         "nanoresource": "^1.3.0",
         "pretty-hash": "^1.0.1",
-        "random-access-file": "^2.1.0",
-        "sodium-universal": "^2.0.0",
         "sparse-bitfield": "^3.0.0",
-        "timeout-refresh": "^1.0.1",
+        "timeout-refresh": "^1.0.3",
         "uint64be": "^2.0.1",
         "unordered-array-remove": "^1.0.2",
         "unordered-set": "^2.0.0"
-      },
-      "dependencies": {
-        "hypercore-crypto": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/hypercore-crypto/-/hypercore-crypto-1.0.0.tgz",
-          "integrity": "sha512-xFwOnNlOt8L+SovC7dTNchKaNYJb5l8rKZZwpWQnCme1r7CU4Hlhp1RDqPES6b0OpS7DkTo9iU0GltQGkpsjMw==",
-          "requires": {
-            "buffer-alloc-unsafe": "^1.1.0",
-            "buffer-from": "^1.1.0",
-            "sodium-universal": "^2.0.0",
-            "uint64be": "^2.0.2"
-          }
-        }
       }
     },
     "hypercore-cache": {
@@ -2169,33 +2502,37 @@
         }
       }
     },
+    "hypercore-default-storage": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hypercore-default-storage/-/hypercore-default-storage-1.1.1.tgz",
+      "integrity": "sha512-y7dSX3VUT4I/X5Cj0h6hcKN2R+/QQIi1HnElnCqY3tQYbVaWYljdbVe3aBQIvkRCfOgWMfe2RbCLX4N78D5syg==",
+      "requires": {
+        "fsctl": "^1.0.0",
+        "random-access-file": "^2.1.5"
+      }
+    },
     "hypercore-protocol": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/hypercore-protocol/-/hypercore-protocol-7.10.0.tgz",
-      "integrity": "sha512-9p+Mm8yTp8pW3EURSSQYSqEcDOWW1Fyg/Pqfxr1WYnWAvotuqPq2lIBSIuUOb6AIvHISuCKRqLxSLfJkvIWZ7g==",
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/hypercore-protocol/-/hypercore-protocol-8.0.7.tgz",
+      "integrity": "sha512-b5TXhqXUZ+Z7M/5/PlCTgElfufDRa3EzACd7y7BA7owLkxQreaUQ58wUO7nzJppDP1bnC2Hz6Hg7nlRPc75bKw==",
       "requires": {
         "abstract-extension": "^3.0.1",
         "debug": "^4.1.1",
-        "hypercore-crypto": "^1.0.0",
+        "hypercore-crypto": "^2.0.0",
         "inspect-custom-symbol": "^1.1.0",
         "nanoguard": "^1.2.1",
         "pretty-hash": "^1.0.1",
-        "simple-hypercore-protocol": "^1.4.0",
+        "simple-hypercore-protocol": "^2.0.0",
         "streamx": "^2.1.0",
         "timeout-refresh": "^1.0.0"
-      },
-      "dependencies": {
-        "hypercore-crypto": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/hypercore-crypto/-/hypercore-crypto-1.0.0.tgz",
-          "integrity": "sha512-xFwOnNlOt8L+SovC7dTNchKaNYJb5l8rKZZwpWQnCme1r7CU4Hlhp1RDqPES6b0OpS7DkTo9iU0GltQGkpsjMw==",
-          "requires": {
-            "buffer-alloc-unsafe": "^1.1.0",
-            "buffer-from": "^1.1.0",
-            "sodium-universal": "^2.0.0",
-            "uint64be": "^2.0.2"
-          }
-        }
+      }
+    },
+    "hypercore-streams": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hypercore-streams/-/hypercore-streams-1.0.1.tgz",
+      "integrity": "sha512-OcN2zq9DEoArC84q9VCSrf9Hx1QUkR6ineCOwyOwhE4v/8aUTOx87mAk1nyjMOf76DQmF+tl2vnS2FssLx5N+Q==",
+      "requires": {
+        "streamx": "^2.6.0"
       }
     },
     "hyperswarm": {
@@ -2206,6 +2543,38 @@
         "@hyperswarm/network": "^2.0.0",
         "shuffled-priority-queue": "^2.1.0",
         "utp-native": "^2.1.7"
+      }
+    },
+    "hyperswarm-proxy": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/hyperswarm-proxy/-/hyperswarm-proxy-1.5.0.tgz",
+      "integrity": "sha512-HsQA5fw7CZbO5RKzuGCOtaWvDxKWD/YZeVHxXL6CeaHHm9JVJaOzwtwwxook8u+E2KMXQczmQsij3ANZSESH3Q==",
+      "requires": {
+        "@hyperswarm/network": "^2.1.0",
+        "length-prefixed-stream": "^2.0.0",
+        "pump": "^3.0.0"
+      }
+    },
+    "hyperswarm-proxy-ws": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hyperswarm-proxy-ws/-/hyperswarm-proxy-ws-1.2.0.tgz",
+      "integrity": "sha512-kX7wjsXjxIv496CpqlKtdikqeHMNEzx5+oJQJaj8pKIOdhdD/Rkbb/w6fy1dQhEKEyXK0N/oPnRBXqNXnbnxhw==",
+      "requires": {
+        "hyperswarm-proxy": "^1.4.0",
+        "websocket-stream": "^5.5.0"
+      }
+    },
+    "hyperswarm-web": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/hyperswarm-web/-/hyperswarm-web-2.1.1.tgz",
+      "integrity": "sha512-uHVIN3ic6Dy5U6xx6pzf0F3WcJ+8clzrk6duZXPltKsHyv619cAO5j62tE+BdDzyzsuDP6bshnvIv+VW7s/vww==",
+      "requires": {
+        "@geut/discovery-swarm-webrtc": "^4.0.1",
+        "duplexpair": "^1.0.1",
+        "hyperswarm-proxy-ws": "^1.2.0",
+        "minimist": "^1.2.0",
+        "send": "^0.17.1",
+        "websocket-stream": "^5.5.2"
       }
     },
     "iconv-lite": {
@@ -2480,6 +2849,11 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
+    "isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="
+    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -2511,6 +2885,11 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true
+    },
+    "json-buffer": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-2.0.11.tgz",
+      "integrity": "sha1-PkQf2jCYvo0eMXGtWRvGKjPi1V8="
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -2587,12 +2966,12 @@
       }
     },
     "kappa-core": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/kappa-core/-/kappa-core-6.0.0.tgz",
-      "integrity": "sha512-d9pb+Ycv6Ug31UBQ9gKocZkkp5w6VAos1eyVePR9ZVxWYUkdgupgKfTYSVlkMlFacLsUdc7lSUpBGXteBjAq8w==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/kappa-core/-/kappa-core-7.0.0.tgz",
+      "integrity": "sha512-JAqz9BzAeCb2K2JeUL9ii6BcdXtinRmcWXiPl0KTfI96NRZhLlylObhL+pNvqnlEOfKumpJNB+Tzdxg66/AzQA==",
       "requires": {
         "inherits": "^2.0.4",
-        "multifeed": "^5.0.0",
+        "multifeed": "^6.0.0",
         "multifeed-index": "^3.3.2"
       }
     },
@@ -2628,6 +3007,16 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/last-one-wins/-/last-one-wins-1.0.4.tgz",
       "integrity": "sha1-wb/Qy8tGeQ7JFWuNGu6Py4bNoio="
+    },
+    "length-prefixed-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/length-prefixed-stream/-/length-prefixed-stream-2.0.0.tgz",
+      "integrity": "sha512-dvjTuWTKWe0oEznQcG6a9osfiYknCs7DEFJMP88n9Y581IFhYh1sZIgAFcuDOojKB0G7ftPreKhh4D0kh/VPjQ==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "varint": "^5.0.0"
+      }
     },
     "level": {
       "version": "6.0.1",
@@ -2778,6 +3167,19 @@
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
+      }
+    },
+    "libsodium": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.9.tgz",
+      "integrity": "sha512-gfeADtR4D/CM0oRUviKBViMGXZDgnFdMKMzHsvBdqLBHd9ySi6EtYnmuhHVDDYgYpAO8eU8hEY+F8vIUAPh08A=="
+    },
+    "libsodium-wrappers": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.9.tgz",
+      "integrity": "sha512-9HaAeBGk1nKTRFRHkt7nzxqCvnkWTjn1pdjKgcUnZxj0FyOP4CnhgFhMdrFfgNsukijBGyBLpP2m2uKT1vuWhQ==",
+      "requires": {
+        "libsodium": "^0.7.0"
       }
     },
     "load-json-file": {
@@ -3034,33 +3436,12 @@
       "dev": true
     },
     "merkle-tree-stream": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/merkle-tree-stream/-/merkle-tree-stream-3.0.3.tgz",
-      "integrity": "sha1-+KBkdg0355eK1fn208EZpJT1cIE=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/merkle-tree-stream/-/merkle-tree-stream-4.0.0.tgz",
+      "integrity": "sha512-TIurLf/ustQNMXi5foClGTcEsRvH6DCvxeAKu68OrwHMOSM/M1pgPXb7qe52Svk1ClvmZuAVpLtP5FWKzPr/sw==",
       "requires": {
         "flat-tree": "^1.3.0",
-        "readable-stream": "^2.0.5"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        }
+        "streamx": "^2.7.1"
       }
     },
     "micromatch": {
@@ -3072,6 +3453,11 @@
         "braces": "^3.0.1",
         "picomatch": "^2.0.5"
       }
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
       "version": "1.44.0",
@@ -3220,6 +3606,19 @@
       "resolved": "https://registry.npmjs.org/monotonic-timestamp/-/monotonic-timestamp-0.0.9.tgz",
       "integrity": "sha1-W6Wtx6rIXh1853voRxYe0kazlgM="
     },
+    "mostly-minimal-spanning-tree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mostly-minimal-spanning-tree/-/mostly-minimal-spanning-tree-1.1.0.tgz",
+      "integrity": "sha512-nw3rZTtFjf+rFtDS2LHCpXKTcS70HiKt7g5piWwDNIz9ImIXwmiyGpyEflvUcU72oY747EbJfRfRSnVN9hGMGQ==",
+      "requires": {
+        "delay": "^4.3.0",
+        "end-of-stream-promise": "^1.0.0",
+        "p-queue": "^6.3.0",
+        "promise-defer": "^1.0.0",
+        "randomize-array": "^1.2.0",
+        "xor-distance": "^2.0.0"
+      }
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -3235,13 +3634,13 @@
       }
     },
     "multifeed": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/multifeed/-/multifeed-5.2.4.tgz",
-      "integrity": "sha512-HgwX0NaaIfcwmImzRrdclVskLhu5lHSB/YgvUZ58+EWyC4qJwSfk4ZGnJ3PKMhAyageRCmTxUTPBshhV8t07wg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/multifeed/-/multifeed-6.0.0.tgz",
+      "integrity": "sha512-PuK9zBYr7lu0WwkDE9kq1523ECi1vOFzS20CHG+2d1ZaGPARNrsGBzYPUvwTueAWpBJPxbpfmR5FORgYQemcOw==",
       "requires": {
         "debug": "^4.1.0",
-        "hypercore": "^8.3.0",
-        "hypercore-protocol": "^7.7.1",
+        "hypercore": "^9.6.0",
+        "hypercore-protocol": "^8.0.7",
         "inherits": "^2.0.3",
         "mutexify": "^1.2.0",
         "once": "^1.4.0",
@@ -3303,11 +3702,6 @@
       "resolved": "https://registry.npmjs.org/mutexify/-/mutexify-1.3.1.tgz",
       "integrity": "sha512-nU7mOEuaXiQIB/EgTIjYZJ7g8KqMm2D8l4qp+DqA4jxWOb/tnb1KEoqp+tlbdQIDIAiC1i7j7X/3yHDFXLxr9g=="
     },
-    "nan": {
-      "version": "2.14.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
-    },
     "nanoassert": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-1.1.0.tgz",
@@ -3323,10 +3717,49 @@
         "remove-array-items": "^1.0.0"
       }
     },
+    "nanocustomassert": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nanocustomassert/-/nanocustomassert-1.0.0.tgz",
+      "integrity": "sha512-oIezVMlrrzPkCtK32NM5y4gU7JPi12NPWrIsXLyH7KL2D3IFYCtNEHSNgabBzoXCMkXI8AO6SMBUSPvJVf6NCA=="
+    },
+    "nanoerror": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/nanoerror/-/nanoerror-1.2.1.tgz",
+      "integrity": "sha512-pCXtdyUZUqkyJjrfKxSMCzdblgVbXOXPdFC+Th80IuQzuoaSwLmMu8rJID92VStrv7sMyqMj86PJMoj//bKcsg==",
+      "requires": {
+        "quick-format-unescaped": "^3.0.3"
+      }
+    },
     "nanoguard": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/nanoguard/-/nanoguard-1.3.0.tgz",
       "integrity": "sha512-K/ON5wyflyPyZskdeT3m7Y2gJVkm3QLdKykMCquAbK8A2erstyMpZUc3NG8Nz5jKdfatiYndONrlmLF8+pGl+A=="
+    },
+    "nanomessage": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/nanomessage/-/nanomessage-8.4.0.tgz",
+      "integrity": "sha512-jLRsKfedD0AwDDPpwoRvxSfx/G9i51peX09/SvrybSD801Y3YmwuXWkxHSS9bNFucqmjo+7/b/Rx5Lngozq3nw==",
+      "requires": {
+        "fastq": "^1.8.0",
+        "nanocustomassert": "^1.0.0",
+        "nanoerror": "^1.1.0",
+        "nanoresource-promise": "^2.0.0",
+        "varint": "^5.0.0"
+      }
+    },
+    "nanomessage-rpc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/nanomessage-rpc/-/nanomessage-rpc-3.2.0.tgz",
+      "integrity": "sha512-CRY3GzkiXa5th7gSTM45v4EZKIVg8XTbhE30PFFbzloTgiPCYBbywkpHGZ+48H/nb2H9gXhbBGDRXbn2hxjH4w==",
+      "requires": {
+        "emittery": "^0.6.0",
+        "end-of-stream": "^1.4.4",
+        "nanocustomassert": "^1.0.0",
+        "nanoerror": "^1.1.0",
+        "nanomessage": "^8.3.0",
+        "nanoresource-promise": "^2.0.0",
+        "varint": "^5.0.0"
+      }
     },
     "nanoresource": {
       "version": "1.3.0",
@@ -3335,6 +3768,11 @@
       "requires": {
         "inherits": "^2.0.4"
       }
+    },
+    "nanoresource-promise": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nanoresource-promise/-/nanoresource-promise-2.0.0.tgz",
+      "integrity": "sha512-C4nHaVqhpRYaSiKfXPC3bOiz5mnS3N1gkDhGaWmYLxr4KTAQdWqOr2pEVw4xVmAHJgA9n9anbfuVOacS/skbIA=="
     },
     "nanoscheduler": {
       "version": "1.0.3",
@@ -3403,6 +3841,11 @@
         }
       }
     },
+    "next-tick": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -3451,14 +3894,21 @@
       }
     },
     "noise-protocol": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/noise-protocol/-/noise-protocol-1.0.0.tgz",
-      "integrity": "sha512-MEseV3jGZGkPPlhJMHrjFHs9XCEcnoYg72hI89GMz/JfDjWEHzhTaTGqHM5gTGtLA9Z04XoGvEI5aCEAqplQrQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/noise-protocol/-/noise-protocol-3.0.1.tgz",
+      "integrity": "sha512-4rQGZvismeb4tMf91O31oDYLGntkEs4p4wa69+14juHTV4A3COtWyDck9PwBqFjg7S8TPZLCUXUdOnOZQJ5UBA==",
       "requires": {
         "clone": "^2.1.2",
-        "hmac-blake2b": "^0.2.0",
-        "nanoassert": "^1.1.0",
-        "sodium-native": "^2.2.1"
+        "hmac-blake2b": "^2.0.0",
+        "nanoassert": "^2.0.0",
+        "sodium-universal": "^3.0.2"
+      },
+      "dependencies": {
+        "nanoassert": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-2.0.0.tgz",
+          "integrity": "sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA=="
+        }
       }
     },
     "nopt": {
@@ -3569,6 +4019,14 @@
         "has": "^1.0.3"
       }
     },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3619,6 +4077,19 @@
         "os-tmpdir": "^1.0.0"
       }
     },
+    "p-event": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-4.2.0.tgz",
+      "integrity": "sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==",
+      "requires": {
+        "p-timeout": "^3.1.0"
+      }
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
     "p-is-promise": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-3.0.0.tgz",
@@ -3641,21 +4112,39 @@
         "p-limit": "^2.0.0"
       }
     },
+    "p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "requires": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      }
+    },
+    "p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "requires": {
+        "p-finally": "^1.0.0"
+      }
+    },
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "paperslip": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/paperslip/-/paperslip-3.0.0.tgz",
-      "integrity": "sha512-iB8xmAdnqqyupMAT3NhhmR9irDGGZNKIQsA4sUgCiCDtHB6KfYoI1x/mH8AK2ELnAyFe1TBhxaQuQBwFt5N4FA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/paperslip/-/paperslip-3.1.0.tgz",
+      "integrity": "sha512-R/tq0OMU4TpRML4FcXOoseEKhDqwloRqW5bQW0z2p0EOg4Et+u9RUS6vEKfwiTu7FiOwzer4ayoqg+F/XZvCDA==",
       "requires": {
         "dedent": "^0.7.0",
         "duplexify": "^3.6.1",
         "human-readable-ids": "^1.0.4",
         "hypercore-crypto": "^2.1.1",
         "hyperswarm": "^2.15.0",
+        "hyperswarm-web": "^2.1.1",
         "minimist": "^1.2.0"
       },
       "dependencies": {
@@ -4003,6 +4492,14 @@
       "resolved": "https://registry.npmjs.org/pretty-hash/-/pretty-hash-1.0.1.tgz",
       "integrity": "sha1-FuBXkYje9WvbVliSvNBaXWUySAc="
     },
+    "private-box": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/private-box/-/private-box-0.3.1.tgz",
+      "integrity": "sha512-abAuk3ZDyQvPLY6MygtwaDTUBIZ0C5wMMuX1jXa0svazV+keTwn7cPobRv4WYA9ctsDUztm/9CYu4y2TPL08xw==",
+      "requires": {
+        "chloride": "^2.2.9"
+      }
+    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -4013,6 +4510,11 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
+    },
+    "promise-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/promise-defer/-/promise-defer-1.0.0.tgz",
+      "integrity": "sha1-JagJPxm6tAxiqORkyX0E/kzcCiQ="
     },
     "prop-types": {
       "version": "15.7.2",
@@ -4087,15 +4589,27 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
-    "query-string": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
-      "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
+    },
+    "queue-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.0.tgz",
+      "integrity": "sha512-ULWhjjE8BmiICGn3G8+1L9wFpERNxkf8ysxkAer4+TFdRefDaXOCV5m92aMB9FtBVmn/8sETXLXY6BfW7hyaWQ=="
+    },
+    "quick-format-unescaped": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.3.tgz",
+      "integrity": "sha512-dy1yjycmn9blucmJLXOfZDx1ikZJUi6E8bBZLnhPG5gBrVhHXx2xVyqqgKBubVNEXmx51dBACMHpoMQK/N/AXQ=="
+    },
+    "random-access-chrome-file": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/random-access-chrome-file/-/random-access-chrome-file-1.1.4.tgz",
+      "integrity": "sha512-xZW1BT26g+gl8AF1kC/oXX97jCMVoLIbf6yx4eVMwLgOddGhhkJygimnfERSEmhUKiGs3DTymNao6wf/P23Nkg==",
       "requires": {
-        "decode-uri-component": "^0.2.0",
-        "filter-obj": "^1.1.0",
-        "split-on-first": "^1.0.0",
-        "strict-uri-encode": "^2.0.0"
+        "random-access-storage": "^1.3.0"
       }
     },
     "random-access-file": {
@@ -4105,6 +4619,54 @@
       "requires": {
         "mkdirp-classic": "^0.5.2",
         "random-access-storage": "^1.1.1"
+      }
+    },
+    "random-access-idb": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/random-access-idb/-/random-access-idb-1.2.1.tgz",
+      "integrity": "sha512-5rZRPhjgfR222n+dmZtRYhu0CF9dDEwxaS+UgeWursIWPmNirR6BajzOB4wG5I7WAeYZea9HCqYKk/Tin3s9cA==",
+      "requires": {
+        "buffer-alloc": "^1.1.0",
+        "buffer-from": "^0.1.1",
+        "inherits": "^2.0.3",
+        "next-tick": "^1.0.0",
+        "once": "^1.4.0",
+        "random-access-storage": "^1.3.0"
+      },
+      "dependencies": {
+        "buffer-from": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
+          "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg=="
+        }
+      }
+    },
+    "random-access-idb-mutable-file": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/random-access-idb-mutable-file/-/random-access-idb-mutable-file-0.3.0.tgz",
+      "integrity": "sha512-CdVAoFNNDn5uAgYOJ8J3ICSaFzaMOa95XnYcX+taj4jirJuRASiTyQSOGR+Z0K8ZkBGuj0A8ivyeRAWuxRCgQA==",
+      "requires": {
+        "buffer": "5.1.0",
+        "random-access-storage": "1.3.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.1.0.tgz",
+          "integrity": "sha512-YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        },
+        "random-access-storage": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/random-access-storage/-/random-access-storage-1.3.0.tgz",
+          "integrity": "sha512-pdS9Mcb9TB7oICypPRALlheaSuszuAKmLVEPKJMuYor7R/zDuHh5ALuQoS+ox31XRwQUL+tDwWH2GPdyspwelA==",
+          "requires": {
+            "inherits": "^2.0.3"
+          }
+        }
       }
     },
     "random-access-memory": {
@@ -4125,6 +4687,19 @@
         "inherits": "^2.0.3"
       }
     },
+    "random-access-web": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/random-access-web/-/random-access-web-2.0.3.tgz",
+      "integrity": "sha512-nN3AAgl4/lTOYMk5Qm44SzFsglOmaG2d0Kh0603umh35+rk9QXYLFf0nFJ0GOv9INBsP9iT1lub24r8PjyCtvA==",
+      "requires": {
+        "@sammacbeth/random-access-idb-mutable-file": "^0.1.1",
+        "random-access-chrome-file": "^1.1.2",
+        "random-access-idb": "^1.2.1",
+        "random-access-idb-mutable-file": "^0.3.0",
+        "random-access-memory": "^3.1.1",
+        "random-access-storage": "^1.3.0"
+      }
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -4132,6 +4707,16 @@
       "requires": {
         "safe-buffer": "^5.1.0"
       }
+    },
+    "randomize-array": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/randomize-array/-/randomize-array-1.2.0.tgz",
+      "integrity": "sha512-3utyf30rF+wc1ZPgl+lTn8WMMGyMNN0uQkyuWo3N/vVT3J2Olt1ymCk3J8+zl4dsvYnplLFd+CLnYlCLT1W0iw=="
+    },
+    "range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "reachdown": {
       "version": "1.1.0",
@@ -4269,6 +4854,11 @@
         "picomatch": "^2.0.4"
       }
     },
+    "reconnecting-websocket": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/reconnecting-websocket/-/reconnecting-websocket-4.4.0.tgz",
+      "integrity": "sha512-D2E33ceRPga0NvTDhJmphEgJ7FUYF0v4lr1ki0csq06OdlxKfugGzN0dSkxM/NfqCxYELK4KcaTOUOjTV6Dcng=="
+    },
     "record-cache": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/record-cache/-/record-cache-1.1.0.tgz",
@@ -4365,8 +4955,7 @@
     "reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
     },
     "rimraf": {
       "version": "3.0.2",
@@ -4414,10 +5003,65 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
       "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
     },
+    "send": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+    },
+    "sha.js": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.5.tgz",
+      "integrity": "sha1-J9Fx78yCoRi5ljn/WBZgJCtQbnw=",
+      "requires": {
+        "inherits": "^2.0.1"
+      }
     },
     "sha256-universal": {
       "version": "1.1.0",
@@ -4502,24 +5146,33 @@
       }
     },
     "simple-handshake": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/simple-handshake/-/simple-handshake-1.3.1.tgz",
-      "integrity": "sha512-3Q6FjXdVFCa5JiLsWFl9s/Wp9hfBI9OqGfnlA/fUqIgR8M6zykFMxgGmV7M3YFbBkXYXQYayj6D6aFDejQcPjA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/simple-handshake/-/simple-handshake-3.0.0.tgz",
+      "integrity": "sha512-8Te0vlxvhpNCMgwnWFTbRR6Re2l8hq8wyXQc3lY9dPYXFxYwVkh79LhDQHFCOWRavmbiOdfqq1l5HT/73Rn2/w==",
       "requires": {
-        "nanoassert": "^1.1.0",
-        "noise-protocol": "^1.0.0"
+        "nanoassert": "^2.0.0",
+        "noise-protocol": "^3.0.0"
+      },
+      "dependencies": {
+        "nanoassert": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-2.0.0.tgz",
+          "integrity": "sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA=="
+        }
       }
     },
     "simple-hypercore-protocol": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/simple-hypercore-protocol/-/simple-hypercore-protocol-1.5.0.tgz",
-      "integrity": "sha512-HEweK2xilxAZ2RjDg770xDKPbKwvIR9OUTRtFLHsepFYiyfFxAoZkUxFkJQMTav935P8ompf6npnIie+d/8Dsw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/simple-hypercore-protocol/-/simple-hypercore-protocol-2.1.2.tgz",
+      "integrity": "sha512-zCwEMw/Evd5iDPkVEjO+1T3OJqbuDukJSuZtMZ7A7Wfn0RxmaJFbwngfUnDNyQFbPMxiINNxGBMD85fFJF8ghA==",
       "requires": {
+        "hypercore-crypto": "^2.1.0",
+        "noise-protocol": "^3.0.1",
         "protocol-buffers-encodings": "^1.1.0",
-        "simple-handshake": "^1.3.1",
+        "simple-handshake": "^3.0.0",
         "simple-message-channels": "^1.2.1",
-        "sodium-universal": "^2.0.0",
-        "varint": "^5.0.0"
+        "varint": "^5.0.0",
+        "xsalsa20-universal": "^1.0.0"
       }
     },
     "simple-message-channels": {
@@ -4528,6 +5181,66 @@
       "integrity": "sha512-knSr69GKW9sCjzpoy817xQelpOASUQ53TXCBcSLDKLE7GTGpUAhZzOZYrdbX2Ig//m+8AIrNp7sM7HDNHBRzXw==",
       "requires": {
         "varint": "^5.0.0"
+      }
+    },
+    "simple-peer": {
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/simple-peer/-/simple-peer-9.11.0.tgz",
+      "integrity": "sha512-qvdNu/dGMHBm2uQ7oLhQBMhYlrOZC1ywXNCH/i8I4etxR1vrjCnU6ZSQBptndB1gcakjo2+w4OHo7Sjza1SHxg==",
+      "requires": {
+        "buffer": "^6.0.3",
+        "debug": "^4.3.1",
+        "err-code": "^3.0.1",
+        "get-browser-rtc": "^1.1.0",
+        "queue-microtask": "^1.2.3",
+        "randombytes": "^2.1.0",
+        "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
+      }
+    },
+    "simple-websocket": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/simple-websocket/-/simple-websocket-9.1.0.tgz",
+      "integrity": "sha512-8MJPnjRN6A8UCp1I+H/dSFyjwJhp6wta4hsVRhjf8w9qBHRzxYt14RaOcjvQnhD1N4yKOddEjflwMnQM4VtXjQ==",
+      "requires": {
+        "debug": "^4.3.1",
+        "queue-microtask": "^1.2.2",
+        "randombytes": "^2.1.0",
+        "readable-stream": "^3.6.0",
+        "ws": "^7.4.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ws": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
+          "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w=="
+        }
       }
     },
     "siphash24": {
@@ -4555,34 +5268,157 @@
         "is-fullwidth-code-point": "^2.0.0"
       }
     },
+    "socket-signal": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/socket-signal/-/socket-signal-9.2.1.tgz",
+      "integrity": "sha512-Q38YElCX6Z1PvaYgqFFA2V45nWiDEYrjVQrs3+5zDNQTY/Kb+JUKRSTnUocHylIZyED6nXqO5/WSBHkFKcvSJw==",
+      "requires": {
+        "debug": "^4.1.1",
+        "end-of-stream": "^1.4.4",
+        "fastq": "^1.8.0",
+        "nanocustomassert": "^1.0.0",
+        "nanoerror": "^1.0.0",
+        "nanomessage-rpc": "^3.2.0",
+        "nanoresource-promise": "^2.0.0",
+        "p-event": "^4.1.0",
+        "p-limit": "^3.0.2",
+        "simple-peer": "^9.6.2"
+      },
+      "dependencies": {
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        }
+      }
+    },
+    "socket-signal-websocket": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/socket-signal-websocket/-/socket-signal-websocket-9.2.4.tgz",
+      "integrity": "sha512-OtBtzKRtGZX2+FN5EGsbckYSM+sVwSqBM1zDQ2Szg2lLwPccol1kONpqc+BveWTiis+j8HBjFBc3BQWO0XQePg==",
+      "requires": {
+        "delay": "^5.0.0",
+        "isomorphic-ws": "^4.0.1",
+        "minimist": "^1.2.5",
+        "nanocustomassert": "^1.0.0",
+        "reconnecting-websocket": "^4.4.0",
+        "simple-websocket": "^9.0.0",
+        "socket-signal": "^9.2.0",
+        "ws": "^8.2.1"
+      },
+      "dependencies": {
+        "delay": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
+          "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw=="
+        }
+      }
+    },
+    "sodium-browserify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sodium-browserify/-/sodium-browserify-1.3.0.tgz",
+      "integrity": "sha512-1KRS6Oew3X13AIZhbmGF0YBdt2pQdafJMfv83OZHWbzxG92YBBnN8HYx/VKmYB4xCe90eidNaDJWBEFw/o3ahw==",
+      "requires": {
+        "libsodium-wrappers": "^0.7.4",
+        "sha.js": "2.4.5",
+        "sodium-browserify-tweetnacl": "^0.2.5",
+        "tweetnacl": "^0.14.1"
+      }
+    },
+    "sodium-browserify-tweetnacl": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/sodium-browserify-tweetnacl/-/sodium-browserify-tweetnacl-0.2.6.tgz",
+      "integrity": "sha512-ZnEI26hdluilpYY28Xc4rc1ALfmEp2TWihkJX6Mdtw0z9RfHfpZJU7P8DoKbN1HcBdU9aJmguFZs7igE8nLJPg==",
+      "requires": {
+        "chloride-test": "^1.1.0",
+        "ed2curve": "^0.1.4",
+        "sha.js": "^2.4.8",
+        "tweetnacl": "^1.0.1",
+        "tweetnacl-auth": "^0.3.0"
+      },
+      "dependencies": {
+        "sha.js": {
+          "version": "2.4.11",
+          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+          "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+          "requires": {
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+          "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+        }
+      }
+    },
+    "sodium-chloride": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sodium-chloride/-/sodium-chloride-1.1.2.tgz",
+      "integrity": "sha512-8AVzr9VHueXqfzfkzUA0aXe/Q4XG3UTmhlP6Pt+HQc5bbAPIJFo7ZIMh9tvn+99QuiMcyDJdYumegGAczl0N+g=="
+    },
     "sodium-javascript": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/sodium-javascript/-/sodium-javascript-0.5.6.tgz",
-      "integrity": "sha512-Uk+JpqHEbzsEmiMxwL7TB/ndhMEpc52KdReYXXSIX2oRFPaI7ZDlDImF8KbkFWbYl9BJRtc82AZ/kNf4/0n9KA==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/sodium-javascript/-/sodium-javascript-0.7.4.tgz",
+      "integrity": "sha512-YUkucU81C0SUYzxcFFLOupOj89BlKA8MU8iTc7vTtd9hwgM/Awxwzz3tuoLGLHhnMxotUBB7Xl0rBeSoIn2yGQ==",
       "requires": {
         "blake2b": "^2.1.1",
-        "nanoassert": "^1.0.0",
+        "chacha20-universal": "^1.0.4",
+        "nanoassert": "^2.0.0",
+        "sha256-universal": "^1.1.0",
+        "sha512-universal": "^1.1.0",
         "siphash24": "^1.0.1",
         "xsalsa20": "^1.0.0"
+      },
+      "dependencies": {
+        "nanoassert": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-2.0.0.tgz",
+          "integrity": "sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA=="
+        }
       }
     },
     "sodium-native": {
-      "version": "2.4.9",
-      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-2.4.9.tgz",
-      "integrity": "sha512-mbkiyA2clyfwAyOFIzMvsV6ny2KrKEIhFVASJxWfsmgfUEymgLIS2MLHHcGIQMkrcKhPErRaMR5Dzv0EEn+BWg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-3.3.0.tgz",
+      "integrity": "sha512-rg6lCDM/qa3p07YGqaVD+ciAbUqm6SoO4xmlcfkbU5r1zIGrguXztLiEtaLYTV5U6k8KSIUFmnU3yQUSKmf6DA==",
       "requires": {
-        "ini": "^1.3.5",
-        "nan": "^2.14.0",
-        "node-gyp-build": "^4.1.0"
+        "node-gyp-build": "^4.3.0"
+      },
+      "dependencies": {
+        "node-gyp-build": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+          "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q=="
+        }
       }
     },
     "sodium-universal": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-2.0.0.tgz",
-      "integrity": "sha512-csdVyakzHJRyCevY4aZC2Eacda8paf+4nmRGF2N7KxCLKY2Ajn72JsExaQlJQ2BiXJncp44p3T+b80cU+2TTsg==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-3.0.4.tgz",
+      "integrity": "sha512-WnBQ0GDo/82shKQHZBZT9h4q4miCtxkbzcwVLsCBPWNq4qbq8BXhKICt9nPwQAsJ43ct/rF61FKu4t0druUBug==",
       "requires": {
-        "sodium-javascript": "~0.5.0",
-        "sodium-native": "^2.0.0"
+        "blake2b": "^2.1.1",
+        "chacha20-universal": "^1.0.4",
+        "nanoassert": "^2.0.0",
+        "resolve": "^1.17.0",
+        "sha256-universal": "^1.1.0",
+        "sha512-universal": "^1.1.0",
+        "siphash24": "^1.0.1",
+        "sodium-javascript": "~0.7.2",
+        "sodium-native": "^3.2.0",
+        "xsalsa20": "^1.0.0"
+      },
+      "dependencies": {
+        "nanoassert": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-2.0.0.tgz",
+          "integrity": "sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA=="
+        }
       }
     },
     "source-map": {
@@ -4637,11 +5473,6 @@
       "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-1.1.0.tgz",
       "integrity": "sha512-z/wAiTESw2XVPssY2XRcme4niTc4S5FkkJ4gknudtVoc33Zil8TdTxHy5torRcgqMqksJV2Yz8HQcvtbsnw0mQ=="
     },
-    "split-on-first": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
-    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -4693,6 +5524,11 @@
         "pkg-conf": "^3.1.0"
       }
     },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
     "stream-collector": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stream-collector/-/stream-collector-1.0.1.tgz",
@@ -4739,22 +5575,18 @@
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "streamx": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.10.2.tgz",
-      "integrity": "sha512-+HETj2wSTg4DLSp6f6UjYnxP0K8skeN8dEie/tbDR2cTX6bj9HNa0g9iSZY/jXowG629al0cq/3zLNlFUKSh7g==",
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.11.3.tgz",
+      "integrity": "sha512-NhcjG/xi33S4O2LRXZnBg7TLhnlE7RKWTeUx3N08K/89PKZ6MehEtSE+aToT5f2Cer2ArX9FwUhVfZbsUjnvrw==",
       "requires": {
-        "fast-fifo": "^1.0.0"
+        "fast-fifo": "^1.0.0",
+        "queue-tick": "^1.0.0"
       }
     },
     "strftime": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.10.0.tgz",
       "integrity": "sha1-s/D6QZKVICpaKJ9ta+n0kJphcZM="
-    },
-    "strict-uri-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string-width": {
       "version": "3.1.0",
@@ -4970,6 +5802,11 @@
         "flush-write-stream": "^1.0.0"
       }
     },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+    },
     "tough-cookie": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -4998,8 +5835,15 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
+    "tweetnacl-auth": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/tweetnacl-auth/-/tweetnacl-auth-0.3.1.tgz",
+      "integrity": "sha1-t1vC3xVkm7hOi5qjwGacbEvODSU=",
+      "requires": {
+        "tweetnacl": "0.x.x"
+      }
     },
     "txt-blit": {
       "version": "1.0.2",
@@ -5054,6 +5898,11 @@
       "requires": {
         "buffer-alloc": "^1.1.0"
       }
+    },
+    "ultron": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
     },
     "uniq": {
       "version": "1.0.1",
@@ -5163,6 +6012,70 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "websocket-stream": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/websocket-stream/-/websocket-stream-5.5.2.tgz",
+      "integrity": "sha512-8z49MKIHbGk3C4HtuHWDtYX8mYej1wWabjthC/RupM9ngeukU4IWoM46dgth1UOS/T4/IqgEdCDJuMe2039OQQ==",
+      "requires": {
+        "duplexify": "^3.5.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.3",
+        "safe-buffer": "^5.1.2",
+        "ws": "^3.2.0",
+        "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "duplexify": {
+          "version": "3.7.1",
+          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+          "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+          "requires": {
+            "end-of-stream": "^1.0.0",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.0",
+            "stream-shift": "^1.0.0"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            }
+          }
+        },
+        "ws": {
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+          "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+          "requires": {
+            "async-limiter": "~1.0.0",
+            "safe-buffer": "~5.1.0",
+            "ultron": "~1.1.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            }
+          }
+        }
+      }
+    },
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -5264,6 +6177,11 @@
         }
       }
     },
+    "ws": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA=="
+    },
     "xor-distance": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/xor-distance/-/xor-distance-2.0.0.tgz",
@@ -5273,6 +6191,30 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/xsalsa20/-/xsalsa20-1.1.0.tgz",
       "integrity": "sha512-zd3ytX2cm+tcSndRU+krm0eL4TMMpZE7evs5hLRAoOy6gviqLfe3qOlkjF3i5SeAkQUCeJk0lJZrEU56kHRfWw=="
+    },
+    "xsalsa20-universal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/xsalsa20-universal/-/xsalsa20-universal-1.0.0.tgz",
+      "integrity": "sha512-0M/X61wiKKAGAMqsxEyJ0kY6NtjpcMiKinYSSsl4K7ypgvqXDTMwQK6hxnYE1s1Jm7h6YKcN8obDUg2CC+jVGA==",
+      "requires": {
+        "sodium-native": "^3.0.1",
+        "xsalsa20": "^1.1.0"
+      },
+      "dependencies": {
+        "node-gyp-build": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+          "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q=="
+        },
+        "sodium-native": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-3.3.0.tgz",
+          "integrity": "sha512-rg6lCDM/qa3p07YGqaVD+ciAbUqm6SoO4xmlcfkbU5r1zIGrguXztLiEtaLYTV5U6k8KSIUFmnU3yQUSKmf6DA==",
+          "requires": {
+            "node-gyp-build": "^4.3.0"
+          }
+        }
+      }
     },
     "xtend": {
       "version": "4.0.2",
@@ -5320,6 +6262,11 @@
         "lodash": "^4.17.15",
         "yargs": "^13.3.0"
       }
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
   },
   "dependencies": {
     "ansi-escapes": "^4.3.1",
-    "cabal-client": "^6.3.1",
-    "cabal-core": "^14.1.2",
+    "cabal-client": "^7.2.0",
     "chalk": "^4.0.0",
     "js-yaml": "^3.13.1",
     "minimist": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "ansi-escapes": "^4.3.1",
     "cabal-client": "^6.3.1",
+    "cabal-core": "^14.1.2",
     "chalk": "^4.0.0",
     "js-yaml": "^3.13.1",
     "minimist": "^1.2.5",

--- a/views.js
+++ b/views.js
@@ -76,8 +76,15 @@ function linkSize (state) {
 
 function renderPrompt (state) {
   var name = util.sanitizeString(state.cabal ? state.cabal.getLocalName() : 'unknown')
+  var channel = state.cabal.getCurrentChannel()
+  var channelName = channel
+  if (state.cabal.isChannelPrivate(channel)) {
+    const recipient = state.cabal.getUsers()[channelName]
+    const recipientName = recipient.name || recipient.slice(0,8)
+    channelName = "pm with " + recipientName
+  }
   return [
-    `[${chalk.cyan(name)}:${state.cabal.getCurrentChannel()}] ${state.neat.input.line()}`
+    `[${chalk.cyan(name)}:${channelName}] ${state.neat.input.line()}`
   ]
 }
 

--- a/views.js
+++ b/views.js
@@ -107,11 +107,18 @@ function renderCabals (state, width, height) {
 }
 
 function renderChannels (state, width, height) {
-  const channels = state.cabal.getJoinedChannels()
+  const channels = state.cabal.getChannels({"includePM": true})
   const numPrefixWidth = String(channels.length).length
-  return channels
+
+  const users = state.cabal.getUsers()
+  return channels 
     .map((channel, idx) => {
+      const isPrivate = state.cabal.isChannelPrivate(channel)
       var channelTruncated = channel.substring(0, width - 5)
+      if (isPrivate) {
+        // if private, `channel` contains the pubkey of who we are chatting with
+        channelTruncated = `+${getPrintedName(users[channel])}`
+      }
       var unread = channel in state.unreadChannels
       var mentioned = channel in state.mentions
 
@@ -126,6 +133,7 @@ function renderChannels (state, width, height) {
       if (state.cabal.getCurrentChannel() === channel) {
         var fillWidth = width - channelTruncated.length - 5
         var fill = (fillWidth > 0) ? new Array(fillWidth).fill(' ').join('') : ''
+        if (isPrivate) return ' ' + chalk.whiteBright(chalk.bgMagenta(numPrefix + channelTruncated + fill))
         if (state.selectedWindowPane === 'channels') {
           return ' ' + chalk.whiteBright(chalk.bgBlue(numPrefix + channelTruncated + fill))
         } else {
@@ -134,6 +142,7 @@ function renderChannels (state, width, height) {
       } else {
         if (mentioned) return ' ' + numPrefix + '@' + chalk.magenta(channelTruncated)
         else if (unread) return ' ' + numPrefix + '*' + chalk.green(channelTruncated)
+        else if (isPrivate) return ' ' + numPrefix + chalk.cyan(channelTruncated)
         else return ' ' + numPrefix + channelTruncated
       }
     }).slice(0, height)
@@ -149,6 +158,11 @@ function renderHorizontalLine (chr, width, chlk) {
   return [txt]
 }
 
+function getPrintedName (user) {
+  if (user && user.name) return user.name
+  else return user.key.slice(0, 8)
+}
+
 function renderNicks (state, width, height) {
   // All known users
   var users = state.cabal.getChannelMembers()
@@ -157,10 +171,6 @@ function renderNicks (state, width, height) {
     .map(key => users[key])
     .sort(util.cmpUser)
 
-  function getPrintedName (user) {
-    if (user && user.name) return user.name
-    else return user.key.slice(0, 8)
-  }
 
   // Count how many occurances of same nickname there are
   const onlineNickCount = {}
@@ -218,7 +228,11 @@ function renderChannelTopic (state, width, height) {
     line = line.substring(0, line.length - 1) + '…'
   }
   line = line + new Array(width - line.length - 1).fill(' ').join('')
-  return [chalk.whiteBright(chalk.bgBlue(line))]
+
+  const isPrivate = state.cabal.isChannelPrivate(state.cabal.channel)
+  // visually distinguish private channel from all other channels
+  if (isPrivate) { return [chalk.whiteBright(chalk.bgMagenta(line))] }
+  else { return [chalk.whiteBright(chalk.bgBlue(line))] }
 }
 
 function renderMessages (state, width, height) {


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/3862362/141294782-0c8d09f3-022b-4d6d-aeb7-fa00d5a01c3b.png)
_two clients chatting over private messages. the right-most client is displaying the new inline PM events, as well as the alternate colouring for PM channels in the channel listing_

This PR adds a support for private messages, including:
* changing the color of pm channels such that they are visually distinct in the channel listing
* changing the main color of the ui when in a pm to make it visually distinct from other channels
* add inline PM events in currently viewed channels to make it easier to keep up on PMs
* make doubly sure that hidden peers never have their PMs displayed

Depends on https://github.com/cabal-club/cabal-client/pull/82 (and indirectly https://github.com/cabal-club/cabal-core/pull/108)