### PR TITLE
bump cabal-client & use onlyJoined when getting channels

### DIFF
--- a/neat-screen.js
+++ b/neat-screen.js
@@ -256,7 +256,7 @@ function NeatScreen (props) {
       if (i < 0) i += this.state.cabals.length
       setCabalByIndex.bind(this)(i)
     } else {
-      var channels = this.state.cabal.getChannels({ includePM: true })
+      var channels = this.state.cabal.getChannels({ includePM: true, onlyJoined: true })
       i = channels.indexOf(this.state.cabal.getCurrentChannel())
       i += dir * 1
       i = i % channels.length
@@ -271,7 +271,7 @@ function NeatScreen (props) {
   }
 
   function setChannelByIndex (n) {
-    var channels = self.state.cabal.getChannels({ includePM: true })
+    var channels = self.state.cabal.getChannels({ includePM: true, onlyJoined: true })
     if (n < 0 || n >= channels.length) return
     self.loadChannel(channels[n])
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,17 +101,6 @@
         "protocol-buffers-encodings": "^1.1.0",
         "record-cache": "^1.1.0",
         "sodium-native": "^3.1.1"
-      },
-      "dependencies": {
-        "sodium-native": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-3.2.1.tgz",
-          "integrity": "sha512-EgDZ/Z7PxL2kCasKk7wnRkV8W9kvwuIlHuHXAxkQm3FF0MgVsjyLBXGjSRGhjE6u7rhSpk3KaMfFM23bfMysIQ==",
-          "requires": {
-            "ini": "^1.3.5",
-            "node-gyp-build": "^4.2.0"
-          }
-        }
       }
     },
     "@hyperswarm/discovery": {
@@ -130,17 +119,6 @@
       "integrity": "sha512-RcczqJsu2VScRoyJdLbxpYMBNq+73HJT3FVzDZXSOob/WqEeiN2WIvuDtvmFoufAuO/3YVfde/NpZFc/OPjmjw==",
       "requires": {
         "sodium-native": "^3.1.1"
-      },
-      "dependencies": {
-        "sodium-native": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-3.2.1.tgz",
-          "integrity": "sha512-EgDZ/Z7PxL2kCasKk7wnRkV8W9kvwuIlHuHXAxkQm3FF0MgVsjyLBXGjSRGhjE6u7rhSpk3KaMfFM23bfMysIQ==",
-          "requires": {
-            "ini": "^1.3.5",
-            "node-gyp-build": "^4.2.0"
-          }
-        }
       }
     },
     "@hyperswarm/network": {
@@ -152,6 +130,11 @@
         "nanoresource": "^1.3.0",
         "utp-native": "^2.2.1"
       }
+    },
+    "@leichtgewicht/ip-codec": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.3.tgz",
+      "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
@@ -235,6 +218,17 @@
         "level-concat-iterator": "~2.0.0",
         "level-supports": "~1.0.0",
         "xtend": "~4.0.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        }
       }
     },
     "acorn": {
@@ -286,7 +280,8 @@
     "ansi-regex": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "dev": true
     },
     "ansi-split": {
       "version": "1.0.1",
@@ -307,6 +302,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -395,6 +391,11 @@
       "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
       "dev": true
     },
+    "b4a": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.3.1.tgz",
+      "integrity": "sha512-ULHjbJGjZcdA5bugDNAAcMA6GWXX/9N10I6AQc14TH+Sr7bMfT+NHuJnOFGPJWLtzYa6Tz+PnFD2D/1bISLLZQ=="
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -438,12 +439,19 @@
       }
     },
     "blake2b": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/blake2b/-/blake2b-2.1.3.tgz",
-      "integrity": "sha512-pkDss4xFVbMb4270aCyGD3qLv92314Et+FsKzilCLxDz5DuZ2/1g3w4nmBbu6nKApPspnjG7JcwTjGZnduB1yg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/blake2b/-/blake2b-2.1.4.tgz",
+      "integrity": "sha512-AyBuuJNI64gIvwx13qiICz6H6hpmjvYS5DGkG6jbXMOT8Z3WUJ3V1X0FlhIoT1b/5JtHE3ki+xjtMvu1nn+t9A==",
       "requires": {
-        "blake2b-wasm": "^1.1.0",
-        "nanoassert": "^1.0.0"
+        "blake2b-wasm": "^2.4.0",
+        "nanoassert": "^2.0.0"
+      },
+      "dependencies": {
+        "nanoassert": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-2.0.0.tgz",
+          "integrity": "sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA=="
+        }
       }
     },
     "blake2b-universal": {
@@ -453,25 +461,22 @@
       "requires": {
         "blake2b": "^2.1.3",
         "sodium-native": "^3.0.1"
-      },
-      "dependencies": {
-        "sodium-native": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-3.2.1.tgz",
-          "integrity": "sha512-EgDZ/Z7PxL2kCasKk7wnRkV8W9kvwuIlHuHXAxkQm3FF0MgVsjyLBXGjSRGhjE6u7rhSpk3KaMfFM23bfMysIQ==",
-          "requires": {
-            "ini": "^1.3.5",
-            "node-gyp-build": "^4.2.0"
-          }
-        }
       }
     },
     "blake2b-wasm": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/blake2b-wasm/-/blake2b-wasm-1.1.7.tgz",
-      "integrity": "sha512-oFIHvXhlz/DUgF0kq5B1CqxIDjIJwh9iDeUUGQUcvgiGz7Wdw03McEO7CfLBy7QKGdsydcMCgO9jFNBAFCtFcA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/blake2b-wasm/-/blake2b-wasm-2.4.0.tgz",
+      "integrity": "sha512-S1kwmW2ZhZFFFOghcx73+ZajEfKBqhP82JMssxtLVMxlaPea1p9uoLiUZ5WYyHn0KddwbLc+0vh4wR0KBNoT5w==",
       "requires": {
-        "nanoassert": "^1.0.0"
+        "b4a": "^1.0.1",
+        "nanoassert": "^2.0.0"
+      },
+      "dependencies": {
+        "nanoassert": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-2.0.0.tgz",
+          "integrity": "sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA=="
+        }
       }
     },
     "brace-expansion": {
@@ -500,12 +505,12 @@
       "dev": true
     },
     "buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "requires": {
         "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
+        "ieee754": "^1.2.1"
       }
     },
     "buffer-alloc": {
@@ -528,9 +533,9 @@
       "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
     },
     "buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "byline": {
       "version": "5.0.0",
@@ -539,9 +544,9 @@
       "dev": true
     },
     "cabal-client": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/cabal-client/-/cabal-client-7.2.0.tgz",
-      "integrity": "sha512-PQaydHnAU0gm3HvzkzC8mhlHtfjou30D7liRWgpVB2E5J3l2QBRBCpN9hkBq8b0x1Dgsux19cbdCJOo/xzhv4w==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/cabal-client/-/cabal-client-7.2.1.tgz",
+      "integrity": "sha512-vPNXripnaklGDTCbx/n8gHkIFJmuar8VsbCh2LR3+R9l1m7K6N8qXHub/ODKT2isrWdRsn5K/DVkOW7KpNp1iA==",
       "requires": {
         "cabal-core": "^15.0.0",
         "collect-stream": "^1.2.1",
@@ -590,221 +595,6 @@
             "through2": "^3.0.1",
             "thunky": "^1.0.3",
             "xtend": "^4.0.1"
-          }
-        }
-      }
-    },
-    "cabal-core": {
-      "version": "14.1.2",
-      "resolved": "https://registry.npmjs.org/cabal-core/-/cabal-core-14.1.2.tgz",
-      "integrity": "sha512-is3x9Sjpon1ZMnwhk4QZp+K5BA7D5mWvX6kdRi5073HrKDDA0jvMTRRgABOcCD6/bIKzlKEJfkzFSyulmPZqig==",
-      "requires": {
-        "charwise": "^3.0.1",
-        "collect-stream": "^1.2.1",
-        "debug": "^4.1.1",
-        "duplexify": "^4.1.1",
-        "hypercore-crypto": "^2.1.1",
-        "hyperswarm": "^2.13.0",
-        "hyperswarm-web": "^2.1.1",
-        "inherits": "^2.0.4",
-        "kappa-core": "^7.0.0",
-        "kappa-view": "^3.1.0",
-        "kappa-view-level": "^2.0.1",
-        "level-mem": "^5.0.1",
-        "materialized-group-auth": "^2.1.0",
-        "monotonic-timestamp": "0.0.9",
-        "once": "^1.4.0",
-        "private-box": "^0.3.1",
-        "pump": "^3.0.0",
-        "read-only-stream": "^2.0.0",
-        "readable-stream": "^3.4.0",
-        "sodium-universal": "^3.0.4",
-        "subleveldown": "^4.1.0",
-        "through2": "^3.0.1",
-        "thunky": "^1.0.3",
-        "xtend": "^4.0.1"
-      },
-      "dependencies": {
-        "hmac-blake2b": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/hmac-blake2b/-/hmac-blake2b-2.0.0.tgz",
-          "integrity": "sha512-JbGNtM1YRd8EQH/2vNTAP1oy5lJVPlBFYZfCJTu3k8sqOUm0rRIf/3+MCd5noVykETwTbun6jEOc+4Tu78ubHA==",
-          "requires": {
-            "nanoassert": "^1.1.0",
-            "sodium-native": "^3.1.1",
-            "sodium-universal": "^3.0.0"
-          },
-          "dependencies": {
-            "nanoassert": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-1.1.0.tgz",
-              "integrity": "sha1-TzFS4JVA/eKMdvRLGbvNHVpCR40="
-            }
-          }
-        },
-        "hypercore": {
-          "version": "9.12.0",
-          "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-9.12.0.tgz",
-          "integrity": "sha512-wIlM4Iwl618NcmsY+1O/X08Cx/bY6ti3LXmQhRnPZFGQPqAeX0x53hASckW082IIAVWzXD3zcmREw5yEINzb4w==",
-          "requires": {
-            "abstract-extension": "^3.0.1",
-            "atomic-batcher": "^1.0.2",
-            "bitfield-rle": "^2.2.1",
-            "codecs": "^2.0.0",
-            "fast-bitfield": "^1.2.2",
-            "flat-tree": "^1.6.0",
-            "hypercore-cache": "^1.0.1",
-            "hypercore-crypto": "^2.0.0",
-            "hypercore-default-storage": "^1.1.1",
-            "hypercore-protocol": "^8.0.5",
-            "hypercore-streams": "^1.0.1",
-            "inherits": "^2.0.3",
-            "inspect-custom-symbol": "^1.1.0",
-            "last-one-wins": "^1.0.4",
-            "memory-pager": "^1.0.2",
-            "merkle-tree-stream": "^4.0.0",
-            "nanoguard": "^1.2.0",
-            "nanoresource": "^1.3.0",
-            "pretty-hash": "^1.0.1",
-            "sparse-bitfield": "^3.0.0",
-            "timeout-refresh": "^1.0.3",
-            "uint64be": "^2.0.1",
-            "unordered-array-remove": "^1.0.2",
-            "unordered-set": "^2.0.0"
-          }
-        },
-        "hypercore-protocol": {
-          "version": "8.0.7",
-          "resolved": "https://registry.npmjs.org/hypercore-protocol/-/hypercore-protocol-8.0.7.tgz",
-          "integrity": "sha512-b5TXhqXUZ+Z7M/5/PlCTgElfufDRa3EzACd7y7BA7owLkxQreaUQ58wUO7nzJppDP1bnC2Hz6Hg7nlRPc75bKw==",
-          "requires": {
-            "abstract-extension": "^3.0.1",
-            "debug": "^4.1.1",
-            "hypercore-crypto": "^2.0.0",
-            "inspect-custom-symbol": "^1.1.0",
-            "nanoguard": "^1.2.1",
-            "pretty-hash": "^1.0.1",
-            "simple-hypercore-protocol": "^2.0.0",
-            "streamx": "^2.1.0",
-            "timeout-refresh": "^1.0.0"
-          }
-        },
-        "kappa-core": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/kappa-core/-/kappa-core-7.0.0.tgz",
-          "integrity": "sha512-JAqz9BzAeCb2K2JeUL9ii6BcdXtinRmcWXiPl0KTfI96NRZhLlylObhL+pNvqnlEOfKumpJNB+Tzdxg66/AzQA==",
-          "requires": {
-            "inherits": "^2.0.4",
-            "multifeed": "^6.0.0",
-            "multifeed-index": "^3.3.2"
-          }
-        },
-        "merkle-tree-stream": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/merkle-tree-stream/-/merkle-tree-stream-4.0.0.tgz",
-          "integrity": "sha512-TIurLf/ustQNMXi5foClGTcEsRvH6DCvxeAKu68OrwHMOSM/M1pgPXb7qe52Svk1ClvmZuAVpLtP5FWKzPr/sw==",
-          "requires": {
-            "flat-tree": "^1.3.0",
-            "streamx": "^2.7.1"
-          }
-        },
-        "multifeed": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/multifeed/-/multifeed-6.0.0.tgz",
-          "integrity": "sha512-PuK9zBYr7lu0WwkDE9kq1523ECi1vOFzS20CHG+2d1ZaGPARNrsGBzYPUvwTueAWpBJPxbpfmR5FORgYQemcOw==",
-          "requires": {
-            "debug": "^4.1.0",
-            "hypercore": "^9.6.0",
-            "hypercore-protocol": "^8.0.7",
-            "inherits": "^2.0.3",
-            "mutexify": "^1.2.0",
-            "once": "^1.4.0",
-            "random-access-file": "^2.0.1",
-            "random-access-memory": "^3.1.1",
-            "through2": "^3.0.0"
-          }
-        },
-        "nanoassert": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-2.0.0.tgz",
-          "integrity": "sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA=="
-        },
-        "node-gyp-build": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
-          "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q=="
-        },
-        "noise-protocol": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/noise-protocol/-/noise-protocol-3.0.1.tgz",
-          "integrity": "sha512-4rQGZvismeb4tMf91O31oDYLGntkEs4p4wa69+14juHTV4A3COtWyDck9PwBqFjg7S8TPZLCUXUdOnOZQJ5UBA==",
-          "requires": {
-            "clone": "^2.1.2",
-            "hmac-blake2b": "^2.0.0",
-            "nanoassert": "^2.0.0",
-            "sodium-universal": "^3.0.2"
-          }
-        },
-        "simple-handshake": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/simple-handshake/-/simple-handshake-3.0.0.tgz",
-          "integrity": "sha512-8Te0vlxvhpNCMgwnWFTbRR6Re2l8hq8wyXQc3lY9dPYXFxYwVkh79LhDQHFCOWRavmbiOdfqq1l5HT/73Rn2/w==",
-          "requires": {
-            "nanoassert": "^2.0.0",
-            "noise-protocol": "^3.0.0"
-          }
-        },
-        "simple-hypercore-protocol": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/simple-hypercore-protocol/-/simple-hypercore-protocol-2.1.2.tgz",
-          "integrity": "sha512-zCwEMw/Evd5iDPkVEjO+1T3OJqbuDukJSuZtMZ7A7Wfn0RxmaJFbwngfUnDNyQFbPMxiINNxGBMD85fFJF8ghA==",
-          "requires": {
-            "hypercore-crypto": "^2.1.0",
-            "noise-protocol": "^3.0.1",
-            "protocol-buffers-encodings": "^1.1.0",
-            "simple-handshake": "^3.0.0",
-            "simple-message-channels": "^1.2.1",
-            "varint": "^5.0.0",
-            "xsalsa20-universal": "^1.0.0"
-          }
-        },
-        "sodium-javascript": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/sodium-javascript/-/sodium-javascript-0.7.3.tgz",
-          "integrity": "sha512-J2Zzj61bo41oBO4yEM9hTaNo3J98AcmFctjRg3D7+0A5cXdB1jlQOHV1qo2NavDU3BpqCfxdHW5UXCv565zh6Q==",
-          "requires": {
-            "blake2b": "^2.1.1",
-            "chacha20-universal": "^1.0.4",
-            "nanoassert": "^2.0.0",
-            "sha256-universal": "^1.1.0",
-            "sha512-universal": "^1.1.0",
-            "siphash24": "^1.0.1",
-            "xsalsa20": "^1.0.0"
-          }
-        },
-        "sodium-native": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-3.3.0.tgz",
-          "integrity": "sha512-rg6lCDM/qa3p07YGqaVD+ciAbUqm6SoO4xmlcfkbU5r1zIGrguXztLiEtaLYTV5U6k8KSIUFmnU3yQUSKmf6DA==",
-          "requires": {
-            "node-gyp-build": "^4.3.0"
-          }
-        },
-        "sodium-universal": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-3.0.4.tgz",
-          "integrity": "sha512-WnBQ0GDo/82shKQHZBZT9h4q4miCtxkbzcwVLsCBPWNq4qbq8BXhKICt9nPwQAsJ43ct/rF61FKu4t0druUBug==",
-          "requires": {
-            "blake2b": "^2.1.1",
-            "chacha20-universal": "^1.0.4",
-            "nanoassert": "^2.0.0",
-            "resolve": "^1.17.0",
-            "sha256-universal": "^1.1.0",
-            "sha512-universal": "^1.1.0",
-            "siphash24": "^1.0.1",
-            "sodium-javascript": "~0.7.2",
-            "sodium-native": "^3.2.0",
-            "xsalsa20": "^1.0.0"
           }
         }
       }
@@ -899,23 +689,6 @@
         "sodium-browserify-tweetnacl": "^0.2.5",
         "sodium-chloride": "^1.1.2",
         "sodium-native": "^3.0.0"
-      },
-      "dependencies": {
-        "node-gyp-build": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
-          "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
-          "optional": true
-        },
-        "sodium-native": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-3.3.0.tgz",
-          "integrity": "sha512-rg6lCDM/qa3p07YGqaVD+ciAbUqm6SoO4xmlcfkbU5r1zIGrguXztLiEtaLYTV5U6k8KSIUFmnU3yQUSKmf6DA==",
-          "optional": true,
-          "requires": {
-            "node-gyp-build": "^4.3.0"
-          }
-        }
       }
     },
     "chloride-test": {
@@ -961,6 +734,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
       "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "dev": true,
       "requires": {
         "string-width": "^3.1.0",
         "strip-ansi": "^5.2.0",
@@ -971,6 +745,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -994,44 +769,13 @@
       "requires": {
         "concat-stream": "^1.2.0",
         "once": "^1.3.0"
-      },
-      "dependencies": {
-        "concat-stream": {
-          "version": "1.6.2",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-          "requires": {
-            "buffer-from": "^1.0.0",
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.2.2",
-            "typedarray": "^0.0.6"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        }
       }
     },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -1039,7 +783,8 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -1213,6 +958,15 @@
             "level-supports": "~1.0.0",
             "xtend": "~4.0.0"
           }
+        },
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
         }
       }
     },
@@ -1280,17 +1034,6 @@
         "stream-collector": "^1.0.1",
         "time-ordered-set": "^1.0.1",
         "xor-distance": "^2.0.0"
-      },
-      "dependencies": {
-        "sodium-native": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-3.2.1.tgz",
-          "integrity": "sha512-EgDZ/Z7PxL2kCasKk7wnRkV8W9kvwuIlHuHXAxkQm3FF0MgVsjyLBXGjSRGhjE6u7rhSpk3KaMfFM23bfMysIQ==",
-          "requires": {
-            "ini": "^1.3.5",
-            "node-gyp-build": "^4.2.0"
-          }
-        }
       }
     },
     "diff": {
@@ -1323,12 +1066,11 @@
       }
     },
     "dns-packet": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-4.2.0.tgz",
-      "integrity": "sha512-bn1AKpfkFbm0MIioOMHZ5qJzl2uypdBwI4nYNsqvhjsegBhcKJUlCrMPWLx6JEezRjxZmxhtIz/FkBEur2l8Cw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.3.0.tgz",
+      "integrity": "sha512-Nce7YLu6YCgWRvOmDBsJMo9M5/jV3lEZ5vUWnWXYmwURvPylHvq7nkDWhNmk1ZQoZZOP7oQh/S0lSxbisKOfHg==",
       "requires": {
-        "ip": "^1.1.5",
-        "safe-buffer": "^5.1.1"
+        "@leichtgewicht/ip-codec": "^2.0.1"
       }
     },
     "doctrine": {
@@ -1411,7 +1153,13 @@
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
+    "encode-utf8": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/encode-utf8/-/encode-utf8-1.0.3.tgz",
+      "integrity": "sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw=="
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -2030,6 +1778,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
       "requires": {
         "locate-path": "^3.0.0"
       }
@@ -2434,6 +2183,16 @@
         "uint64be": "^2.0.1",
         "unordered-array-remove": "^1.0.2",
         "unordered-set": "^2.0.0"
+      },
+      "dependencies": {
+        "uint64be": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/uint64be/-/uint64be-2.0.2.tgz",
+          "integrity": "sha512-9QqdvpGQTXgxthP+lY4e/gIBy+RuqcBaC6JVwT5I3bDLgT/btL6twZMR0pI3/Fgah9G/pdwzIprE5gL6v9UvyQ==",
+          "requires": {
+            "buffer-alloc": "^1.1.0"
+          }
+        }
       }
     },
     "hypercore-cache": {
@@ -2442,64 +2201,12 @@
       "integrity": "sha512-AJ/q7y6EOrXnOH/4+DVcfDygsh1ZXMRGvNc67GBNqwCt22oSCOWhRI6EJ+3HEJciM9M2oSm1WX3qg6kgRhT/Gw=="
     },
     "hypercore-crypto": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/hypercore-crypto/-/hypercore-crypto-2.2.0.tgz",
-      "integrity": "sha512-YawYfsZl0RfKByNwir3ToNeGfKL4KVgEEQ/E/ZVLvYby+ayQ9wmNtqZlyW63YY9vdZ1d0i8WuYZnHb3H3z8qOQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/hypercore-crypto/-/hypercore-crypto-2.3.2.tgz",
+      "integrity": "sha512-GzHgVOfr5utdiJG5QNcQZ0oo+/YQNbekpg429x00YpUobBraX2qEL3E+iH/EFEIdCQSiGHfToWyYw+OpznSjww==",
       "requires": {
         "sodium-universal": "^3.0.0",
         "uint64be": "^3.0.0"
-      },
-      "dependencies": {
-        "nanoassert": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-2.0.0.tgz",
-          "integrity": "sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA=="
-        },
-        "sodium-javascript": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/sodium-javascript/-/sodium-javascript-0.7.3.tgz",
-          "integrity": "sha512-J2Zzj61bo41oBO4yEM9hTaNo3J98AcmFctjRg3D7+0A5cXdB1jlQOHV1qo2NavDU3BpqCfxdHW5UXCv565zh6Q==",
-          "requires": {
-            "blake2b": "^2.1.1",
-            "chacha20-universal": "^1.0.4",
-            "nanoassert": "^2.0.0",
-            "sha256-universal": "^1.1.0",
-            "sha512-universal": "^1.1.0",
-            "siphash24": "^1.0.1",
-            "xsalsa20": "^1.0.0"
-          }
-        },
-        "sodium-native": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-3.2.1.tgz",
-          "integrity": "sha512-EgDZ/Z7PxL2kCasKk7wnRkV8W9kvwuIlHuHXAxkQm3FF0MgVsjyLBXGjSRGhjE6u7rhSpk3KaMfFM23bfMysIQ==",
-          "requires": {
-            "ini": "^1.3.5",
-            "node-gyp-build": "^4.2.0"
-          }
-        },
-        "sodium-universal": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-3.0.4.tgz",
-          "integrity": "sha512-WnBQ0GDo/82shKQHZBZT9h4q4miCtxkbzcwVLsCBPWNq4qbq8BXhKICt9nPwQAsJ43ct/rF61FKu4t0druUBug==",
-          "requires": {
-            "blake2b": "^2.1.1",
-            "chacha20-universal": "^1.0.4",
-            "nanoassert": "^2.0.0",
-            "resolve": "^1.17.0",
-            "sha256-universal": "^1.1.0",
-            "sha512-universal": "^1.1.0",
-            "siphash24": "^1.0.1",
-            "sodium-javascript": "~0.7.2",
-            "sodium-native": "^3.2.0",
-            "xsalsa20": "^1.0.0"
-          }
-        },
-        "uint64be": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/uint64be/-/uint64be-3.0.0.tgz",
-          "integrity": "sha512-mliiCSrsE29aNBI7O9W5gGv6WmA9kBR8PtTt6Apaxns076IRdYrrtFhXHEWMj5CSum3U7cv7/pi4xmi4XsIOqg=="
-        }
       }
     },
     "hypercore-default-storage": {
@@ -2633,11 +2340,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
-    "ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
-    },
     "inquirer": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
@@ -2734,11 +2436,6 @@
         "p-is-promise": "^3.0.0"
       }
     },
-    "ip": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
-    },
     "ipv4-peers": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ipv4-peers/-/ipv4-peers-2.0.0.tgz",
@@ -2786,7 +2483,8 @@
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
     },
     "is-glob": {
       "version": "4.0.1",
@@ -2804,9 +2502,12 @@
       "dev": true
     },
     "is-options": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-options/-/is-options-1.0.1.tgz",
-      "integrity": "sha512-2Xj8sA0zDrAcaoWfBiNmc6VPWAgKDpim0T3J9Djq7vbm1UjwbUWzeuLu/FwC46g3cBbAn0E5R0xwVtOobM6Xxg=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-options/-/is-options-1.0.2.tgz",
+      "integrity": "sha512-u+Ai74c8Q74aS8BuHwPdI1jptGOT1FQXgCq8/zv0xRuE+wRgSMEJLj8lVO8Zp9BeGb29BXY6AsNPinfqjkr7Fg==",
+      "requires": {
+        "b4a": "^1.1.1"
+      }
     },
     "is-regex": {
       "version": "1.1.0",
@@ -3034,6 +2735,17 @@
       "integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
       "requires": {
         "buffer": "^5.6.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        }
       }
     },
     "level-concat-iterator": {
@@ -3080,6 +2792,15 @@
             "level-concat-iterator": "~2.0.0",
             "level-supports": "~1.0.0",
             "xtend": "~4.0.0"
+          }
+        },
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
           }
         }
       }
@@ -3140,6 +2861,15 @@
             "xtend": "~4.0.0"
           }
         },
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        },
         "node-gyp-build": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.1.1.tgz",
@@ -3198,6 +2928,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
       "requires": {
         "p-locate": "^3.0.0",
         "path-exists": "^3.0.0"
@@ -3417,6 +3148,15 @@
             "xtend": "~4.0.0"
           }
         },
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        },
         "immediate": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
@@ -3625,11 +3365,11 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multicast-dns": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.2.tgz",
-      "integrity": "sha512-XqSMeO8EWV/nOXOpPV8ztIpNweVfE1dSpz6SQvDPp71HD74lMXjt4m/mWB1YBMG0kHtOodxRWc5WOb/UNN1A5g==",
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.4.tgz",
+      "integrity": "sha512-XkCYOU+rr2Ft3LI6w4ye51M3VK31qJXFIxu0XLw169PtKG0Zx47OrXeVW/GCYOfpC9s1yyyf1S+L8/4LY0J9Zw==",
       "requires": {
-        "dns-packet": "^4.0.0",
+        "dns-packet": "^5.2.2",
         "thunky": "^1.0.2"
       }
     },
@@ -3698,9 +3438,12 @@
       "dev": true
     },
     "mutexify": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mutexify/-/mutexify-1.3.1.tgz",
-      "integrity": "sha512-nU7mOEuaXiQIB/EgTIjYZJ7g8KqMm2D8l4qp+DqA4jxWOb/tnb1KEoqp+tlbdQIDIAiC1i7j7X/3yHDFXLxr9g=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/mutexify/-/mutexify-1.4.0.tgz",
+      "integrity": "sha512-pbYSsOrSB/AKN5h/WzzLRMFgZhClWccf2XIB4RSMC8JbquiB0e0/SH5AIfdQMdyHmYtv4seU7yV/TvAwPLJ1Yg==",
+      "requires": {
+        "queue-tick": "^1.0.0"
+      }
     },
     "nanoassert": {
       "version": "1.1.0",
@@ -3881,9 +3624,9 @@
       }
     },
     "node-gyp-build": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
-      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+      "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q=="
     },
     "node-webcam": {
       "version": "0.5.0",
@@ -4108,6 +3851,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
       "requires": {
         "p-limit": "^2.0.0"
       }
@@ -4201,7 +3945,8 @@
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -4477,9 +4222,9 @@
       }
     },
     "pngjs": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
-      "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -4563,23 +4308,148 @@
       "dev": true
     },
     "qrcode": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.4.4.tgz",
-      "integrity": "sha512-oLzEC5+NKFou9P0bMj5+v6Z40evexeE29Z9cummZXZ9QXyMr3lphkURzxjXgPJC5azpxcshoDWV1xE46z+/c3Q==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.0.tgz",
+      "integrity": "sha512-9MgRpgVc+/+47dFvQeD6U2s0Z92EsKzcHogtum4QB+UNd025WOJSHvn/hjk9xmzj7Stj95CyUAs31mrjxliEsQ==",
       "requires": {
-        "buffer": "^5.4.3",
-        "buffer-alloc": "^1.2.0",
-        "buffer-from": "^1.1.1",
         "dijkstrajs": "^1.0.1",
-        "isarray": "^2.0.1",
-        "pngjs": "^3.3.0",
-        "yargs": "^13.2.4"
+        "encode-utf8": "^1.0.3",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
       },
       "dependencies": {
-        "isarray": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "6.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+              "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+              "requires": {
+                "ansi-regex": "^5.0.1"
+              }
+            }
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "yargs": {
+          "version": "15.4.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
         }
       }
     },
@@ -4605,9 +4475,9 @@
       "integrity": "sha512-dy1yjycmn9blucmJLXOfZDx1ikZJUi6E8bBZLnhPG5gBrVhHXx2xVyqqgKBubVNEXmx51dBACMHpoMQK/N/AXQ=="
     },
     "random-access-chrome-file": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/random-access-chrome-file/-/random-access-chrome-file-1.1.4.tgz",
-      "integrity": "sha512-xZW1BT26g+gl8AF1kC/oXX97jCMVoLIbf6yx4eVMwLgOddGhhkJygimnfERSEmhUKiGs3DTymNao6wf/P23Nkg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/random-access-chrome-file/-/random-access-chrome-file-1.2.0.tgz",
+      "integrity": "sha512-M1NOdkHEcjRB+acKrdQkwf8aMTnZUIGboiH6i2PMNkjfChBIJiB4j4MuhpOn+u+XU2n7GqpocPN4bzfv0jrBsg==",
       "requires": {
         "random-access-storage": "^1.3.0"
       }
@@ -4670,9 +4540,9 @@
       }
     },
     "random-access-memory": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/random-access-memory/-/random-access-memory-3.1.2.tgz",
-      "integrity": "sha512-wIfh4OZ9T+FRNf6rbXLvEb4FfSxyZpvGnC5kC7Xi39SyPkRYfeJyR9Xwa13iLbNyoNKNIkTFUE4g9lXFb1ZflA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/random-access-memory/-/random-access-memory-3.1.4.tgz",
+      "integrity": "sha512-rqgqd/8ec65gbpKaYHnDOW391OR39d+eXn8NI87G+f3sUKrtGib9jC+/5/9MBFBwwHAZIS8RLJ8yyB4etzbYTA==",
       "requires": {
         "inherits": "^2.0.3",
         "is-options": "^1.0.1",
@@ -4680,11 +4550,12 @@
       }
     },
     "random-access-storage": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/random-access-storage/-/random-access-storage-1.4.1.tgz",
-      "integrity": "sha512-DbCc2TIzOxPaHF6KCbr8zLtiYOJQQQCBHUVNHV/SckUQobCBB2YkDtbLdxGnPwPNpJfEyMWxDAm36A2xkbxxtw==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/random-access-storage/-/random-access-storage-1.4.2.tgz",
+      "integrity": "sha512-nW7UQGxcihvSLuK9PahoKL0jlmw2S6yGV8DsC85xHuUBLJrUoetRbQ5LzuXTt+FWp/iXgjp12x7zh55NNghaBg==",
       "requires": {
-        "inherits": "^2.0.3"
+        "inherits": "^2.0.3",
+        "queue-tick": "^1.0.0"
       }
     },
     "random-access-web": {
@@ -4860,9 +4731,9 @@
       "integrity": "sha512-D2E33ceRPga0NvTDhJmphEgJ7FUYF0v4lr1ki0csq06OdlxKfugGzN0dSkxM/NfqCxYELK4KcaTOUOjTV6Dcng=="
     },
     "record-cache": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/record-cache/-/record-cache-1.1.0.tgz",
-      "integrity": "sha512-u8rbtLEJV7HRacl/ZYwSBFD8NFyB3PfTTfGLP37IW3hftQCwu6z4Q2RLyxo1YJUNRTEzJfpLpGwVuEYdaIkG9Q=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/record-cache/-/record-cache-1.1.1.tgz",
+      "integrity": "sha512-L5hZlgWc7CmGbztnemQoKE1bLu9rtI2skOB0ttE4C5+TVszLE8Rd0YLTROSgvXKLAqPumS/soyN5tJW5wJLmJQ=="
     },
     "regenerator-runtime": {
       "version": "0.13.5",
@@ -5064,18 +4935,20 @@
       }
     },
     "sha256-universal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/sha256-universal/-/sha256-universal-1.1.0.tgz",
-      "integrity": "sha512-CDpS+UrEMA7UOPdogFJ1HOPNrhj0vH+mzWHT5FaU0qlsEXQ4BBey2Mc5+TfJ5nxyRf77fpABbKmXbL/QIzgz2A==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sha256-universal/-/sha256-universal-1.2.1.tgz",
+      "integrity": "sha512-ghn3muhdn1ailCQqqceNxRgkOeZSVfSE13RQWEg6njB+itsFzGVSJv+O//2hvNXZuxVIRyNzrgsZ37SPDdGJJw==",
       "requires": {
-        "sha256-wasm": "^2.1.0"
+        "b4a": "^1.0.1",
+        "sha256-wasm": "^2.2.1"
       }
     },
     "sha256-wasm": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/sha256-wasm/-/sha256-wasm-2.1.2.tgz",
-      "integrity": "sha512-MOddGVQmN+uULS6jnEUk7NzN57yxkT19Lbm5Mlz8mJKONx5ciFDnABZO8VokSJyvBsLCiR7cAOinMToEsifq0w==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/sha256-wasm/-/sha256-wasm-2.2.2.tgz",
+      "integrity": "sha512-qKSGARvao+JQlFiA+sjJZhJ/61gmW/3aNLblB2rsgIxDlDxsJPHo8a1seXj12oKtuHVgJSJJ7QEGBUYQN741lQ==",
       "requires": {
+        "b4a": "^1.0.1",
         "nanoassert": "^2.0.0"
       },
       "dependencies": {
@@ -5087,18 +4960,20 @@
       }
     },
     "sha512-universal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/sha512-universal/-/sha512-universal-1.1.0.tgz",
-      "integrity": "sha512-2ag5no5DwP9lv6Nk8VkJNujqv5LiJODxReqNp2qiY+O1c1bgiN/PlCRdmjQdBp0k/2XAkdIirEPDpZJoGf9gLw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sha512-universal/-/sha512-universal-1.2.1.tgz",
+      "integrity": "sha512-kehYuigMoRkIngCv7rhgruLJNNHDnitGTBdkcYbCbooL8Cidj/bS78MDxByIjcc69M915WxcQTgZetZ1JbeQTQ==",
       "requires": {
-        "sha512-wasm": "^2.1.0"
+        "b4a": "^1.0.1",
+        "sha512-wasm": "^2.3.1"
       }
     },
     "sha512-wasm": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/sha512-wasm/-/sha512-wasm-2.1.1.tgz",
-      "integrity": "sha512-v6t7N3YkJzc4UUhel6fpc423O+7pqlKARUrUOAthgBL3LSncb74qnUXljyd8q24+twG7yC/Kh/ouo6wc2L4oVw==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/sha512-wasm/-/sha512-wasm-2.3.3.tgz",
+      "integrity": "sha512-x8McxarTu+Wv5hu5TQE4qgSSGQ3JOX/OmkhLGVty+ajcEN6zLPqTS6Ljt/N6Gl2jI+3y0wjj+RxDxy8Ca9Krfw==",
       "requires": {
+        "b4a": "^1.0.1",
         "nanoassert": "^2.0.0"
       },
       "dependencies": {
@@ -5197,19 +5072,10 @@
         "readable-stream": "^3.6.0"
       },
       "dependencies": {
-        "buffer": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.2.1"
-          }
-        },
         "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
           "requires": {
             "ms": "2.1.2"
           }
@@ -5229,26 +5095,33 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
           "requires": {
             "ms": "2.1.2"
           }
         },
         "ws": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
-          "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w=="
+          "version": "7.5.6",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
+          "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA=="
         }
       }
     },
     "siphash24": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/siphash24/-/siphash24-1.1.1.tgz",
-      "integrity": "sha512-dKKwjIoTOa587TARYLlBRXq2lkbu5Iz35XrEVWpelhBP1m8r2BGOy1QlaZe84GTFHG/BTucEUd2btnNc8QzIVA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/siphash24/-/siphash24-1.3.0.tgz",
+      "integrity": "sha512-2HvNPUYcmoFks2IX2wI5D80NspdlgSJlCmPencbBMWhrZnNW3sgiC7owaB2Jj/9IiV9bdN2A00LaM8IcojB8rw==",
       "requires": {
-        "nanoassert": "^1.0.0"
+        "nanoassert": "^2.0.0"
+      },
+      "dependencies": {
+        "nanoassert": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-2.0.0.tgz",
+          "integrity": "sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA=="
+        }
       }
     },
     "slash": {
@@ -5388,13 +5261,6 @@
       "integrity": "sha512-rg6lCDM/qa3p07YGqaVD+ciAbUqm6SoO4xmlcfkbU5r1zIGrguXztLiEtaLYTV5U6k8KSIUFmnU3yQUSKmf6DA==",
       "requires": {
         "node-gyp-build": "^4.3.0"
-      },
-      "dependencies": {
-        "node-gyp-build": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
-          "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q=="
-        }
       }
     },
     "sodium-universal": {
@@ -5575,9 +5441,9 @@
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "streamx": {
-      "version": "2.11.3",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.11.3.tgz",
-      "integrity": "sha512-NhcjG/xi33S4O2LRXZnBg7TLhnlE7RKWTeUx3N08K/89PKZ6MehEtSE+aToT5f2Cer2ArX9FwUhVfZbsUjnvrw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.12.0.tgz",
+      "integrity": "sha512-PR93KgPkga2p27UhCI9lf096qPyRMDn/zemRQeAgr1azVLDMr8tZZGpgfEw2/cYY/8mTU4dshLMGNYBsNeQGQw==",
       "requires": {
         "fast-fifo": "^1.0.0",
         "queue-tick": "^1.0.0"
@@ -5592,6 +5458,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
       "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dev": true,
       "requires": {
         "emoji-regex": "^7.0.1",
         "is-fullwidth-code-point": "^2.0.0",
@@ -5602,6 +5469,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -5892,12 +5760,9 @@
       "dev": true
     },
     "uint64be": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/uint64be/-/uint64be-2.0.2.tgz",
-      "integrity": "sha512-9QqdvpGQTXgxthP+lY4e/gIBy+RuqcBaC6JVwT5I3bDLgT/btL6twZMR0pI3/Fgah9G/pdwzIprE5gL6v9UvyQ==",
-      "requires": {
-        "buffer-alloc": "^1.1.0"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/uint64be/-/uint64be-3.0.0.tgz",
+      "integrity": "sha512-mliiCSrsE29aNBI7O9W5gGv6WmA9kBR8PtTt6Apaxns076IRdYrrtFhXHEWMj5CSum3U7cv7/pi4xmi4XsIOqg=="
     },
     "ultron": {
       "version": "1.1.1",
@@ -5963,9 +5828,9 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utp-native": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/utp-native/-/utp-native-2.3.0.tgz",
-      "integrity": "sha512-5dV711teCP21FIRndcq44ETDPL00TnRVmEnINu3jxyg0tq//ptxOyq7oNO6TcMmuFfeFZRSYOqDmTUl8MmPauQ==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/utp-native/-/utp-native-2.5.3.tgz",
+      "integrity": "sha512-sWTrWYXPhhWJh+cS2baPzhaZc89zwlWCfwSthUjGhLkZztyPhcQllo+XVVCbNGi7dhyRlxkWxN4NKU6FbA9Y8w==",
       "requires": {
         "napi-macros": "^2.0.0",
         "node-gyp-build": "^4.2.0",
@@ -6136,6 +6001,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
       "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.0",
         "string-width": "^3.0.0",
@@ -6146,6 +6012,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -6178,9 +6045,9 @@
       }
     },
     "ws": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA=="
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.3.0.tgz",
+      "integrity": "sha512-Gs5EZtpqZzLvmIM59w4igITU57lrtYVFneaa434VROv4thzJyV6UjIL3D42lslWlI+D4KzLYnxSwtfuiO79sNw=="
     },
     "xor-distance": {
       "version": "2.0.0",
@@ -6188,9 +6055,9 @@
       "integrity": "sha512-AsAqZfPAuWx7qB/0kyRDUEvoU3QKsHWzHU9smFlkaiprEpGfJ/NBbLze2Uq0rdkxCxkNM9uOLvz/KoNBCbZiLQ=="
     },
     "xsalsa20": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/xsalsa20/-/xsalsa20-1.1.0.tgz",
-      "integrity": "sha512-zd3ytX2cm+tcSndRU+krm0eL4TMMpZE7evs5hLRAoOy6gviqLfe3qOlkjF3i5SeAkQUCeJk0lJZrEU56kHRfWw=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/xsalsa20/-/xsalsa20-1.2.0.tgz",
+      "integrity": "sha512-FIr/DEeoHfj7ftfylnoFt3rAIRoWXpx2AoDfrT2qD2wtp7Dp+COajvs/Icb7uHqRW9m60f5iXZwdsJJO3kvb7w=="
     },
     "xsalsa20-universal": {
       "version": "1.0.0",
@@ -6199,21 +6066,6 @@
       "requires": {
         "sodium-native": "^3.0.1",
         "xsalsa20": "^1.1.0"
-      },
-      "dependencies": {
-        "node-gyp-build": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
-          "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q=="
-        },
-        "sodium-native": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-3.3.0.tgz",
-          "integrity": "sha512-rg6lCDM/qa3p07YGqaVD+ciAbUqm6SoO4xmlcfkbU5r1zIGrguXztLiEtaLYTV5U6k8KSIUFmnU3yQUSKmf6DA==",
-          "requires": {
-            "node-gyp-build": "^4.3.0"
-          }
-        }
       }
     },
     "xtend": {
@@ -6230,6 +6082,7 @@
       "version": "13.3.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
       "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "dev": true,
       "requires": {
         "cliui": "^5.0.0",
         "find-up": "^3.0.0",
@@ -6247,6 +6100,7 @@
       "version": "13.1.2",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
       "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "dev": true,
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "ansi-escapes": "^4.3.1",
-    "cabal-client": "^7.2.0",
+    "cabal-client": "^7.2.1",
     "chalk": "^4.0.0",
     "js-yaml": "^3.13.1",
     "minimist": "^1.2.5",


### PR DESCRIPTION
patches the cli to make sure the interface only displays joined channels (and not all channels); fixes a regression after moving from using `cabalDetails:getJoinedChannels`  -> `cabalDetails.getChannels`—the latter of which was adapted to include private channels in a way that made it easy to implement cli-style interfaces

uses https://github.com/cabal-club/cabal-client/pull/84