### PR TITLE
Enable leaving of PMs

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "ansi-escapes": "^4.3.1",
-    "cabal-client": "^7.2.1",
+    "cabal-client": "^7.3.0",
     "chalk": "^4.0.0",
     "js-yaml": "^3.13.1",
     "minimist": "^1.2.5",

--- a/views.js
+++ b/views.js
@@ -80,7 +80,7 @@ function renderPrompt (state) {
   var channelName = channel
   if (state.cabal.isChannelPrivate(channel)) {
     const recipient = state.cabal.getUsers()[channelName]
-    const recipientName = recipient.name || recipient.slice(0,8)
+    const recipientName = recipient.name || recipient.key.slice(0,8)
     channelName = "pm with " + recipientName
   }
   return [


### PR DESCRIPTION
Thanks to @dchiquito, cabal-client now has the ability to leave PMs!

I used cabal-cli to find some UX issues that needed to be tweaked before merging cabal-client, and also found a bug in cabal-cli itself. This PR fixes the bug and bumps the cabal-client version.