### PR TITLE
Reports a human-friendly error on bad cabal name.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -490,7 +490,11 @@ function start (keys, frontendConfig) {
       })
     }
   }).catch((e) => {
-    if (e) { console.error(e) } else { console.error("Error: Couldn't resolve one of the following cabal keys:", chalk.yellow(keys.join(' '))) }
+    if (!e || e.toString() === 'Error: dns failed to resolve') {
+      console.error("Error: Couldn't resolve one of the following cabal keys:", chalk.yellow(keys.join(' ')))
+    } else {
+      console.error(e)
+    }
     process.exit(1)
   })
 }


### PR DESCRIPTION
Reports something nicer than an error dump. I've gotten this a lot when I mistype an alias, like `cabal pb` instead of `cabal pub` fo the public cabal.

Depends on https://github.com/cabal-club/cabal-client/pull/94